### PR TITLE
fix(docker): include build.rs in builder COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@
 FROM rust:1.89-slim-bookworm AS builder
 WORKDIR /build
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
 COPY src ./src
+# build.rs reads .git/HEAD if present to stamp HONEYMCP_GIT_SHA. The build
+# context here usually has no .git tree, so the script falls back to "unknown"
+# at compile time. Release builds populate it via CI env (see release.yml).
 RUN cargo build --release --locked
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary

PR #17 added `build.rs` to stamp `HONEYMCP_GIT_SHA` + `HONEYMCP_BUILD_UNIX_TS`. The Dockerfile builder stage did not copy it, so `cargo build --release --locked` errored:

```
error: environment variable \`HONEYMCP_BUILD_UNIX_TS\` not defined at compile time
   --> src/transport/http.rs:340:29
```

This adds `build.rs` to the COPY and notes that in-image builds have no `.git`, so `git_sha` falls back to `"unknown"` inside the image (CI release builds run on a checked-out workspace and stamp it correctly).

## Test plan

- [x] `docker build .` (will be re-run after merge to confirm fix; CI does not exercise docker build in this workflow)