### PR TITLE
ci: add docker build + smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,77 @@ jobs:
           command: check
           arguments: --all-features
 
+  docker:
+    name: docker build + smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v4
+
+      # Build the same Dockerfile that ships releases. Caching on a CI box
+      # buys ~3 minutes per run; --load is required so the smoke step below
+      # can `docker run` the result.
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: honeymcp:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Smoke: bring it up against a real persona, give it a second to bind,
+      # then assert the three endpoints a deploy-time check would hit. If any
+      # of these regress, a deploy on Friday afternoon catches it; without
+      # this job the regression only surfaces when a human runs `docker run`
+      # against the merged main (see PR #18 — exactly that bug got merged
+      # because cargo CI never exercised the Dockerfile).
+      - name: Run + smoke /healthz, /version, /
+        run: |
+          set -euo pipefail
+          docker run -d --rm --name honey-ci -p 8080:8080 \
+            -e HONEYMCP_BANNER_CONTROLLER=ci \
+            -e HONEYMCP_BANNER_ABUSE_EMAIL=ci@example.invalid \
+            honeymcp:ci
+          # Wait up to 15s for healthz; container needs a moment to bind.
+          for i in $(seq 1 15); do
+            if curl -fsS --max-time 1 http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+              echo "ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+          echo "--- /healthz ---"
+          curl -fsS http://127.0.0.1:8080/healthz | grep -qx ok
+
+          echo "--- /version ---"
+          v=$(curl -fsS http://127.0.0.1:8080/version)
+          echo "$v"
+          echo "$v" | jq -e '.name == "honeymcp"' >/dev/null
+          echo "$v" | jq -e '.version | length > 0' >/dev/null
+          echo "$v" | jq -e '.build_unix_ts | tonumber > 0' >/dev/null
+          echo "$v" | jq -e '.build_time_utc | endswith("Z")' >/dev/null
+
+          echo "--- GET / (Accept: text/plain → operator banner) ---"
+          curl -fsS -H 'Accept: text/plain' http://127.0.0.1:8080/ \
+            | grep -qi 'honeypot'
+
+          echo "--- POST /mcp initialize (Streamable HTTP) ---"
+          curl -fsS --max-time 5 -X POST http://127.0.0.1:8080/mcp \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18"}}' \
+            | jq -e '.result.protocolVersion | length > 0' >/dev/null
+
+      - name: Container logs (always, for postmortem)
+        if: always()
+        run: docker logs honey-ci || true
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f honey-ci || true
+
   coverage:
     name: coverage (llvm-cov)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a \`docker\` job to \`.github/workflows/ci.yml\` that:

1. Builds the production \`Dockerfile\` (cached via \`type=gha\`).
2. Brings the container up against a real persona.
3. Asserts \`/healthz\` returns \`ok\`.
4. Asserts \`/version\` returns the expected JSON shape (\`name\`, \`version\`, positive \`build_unix_ts\`, RFC3339 \`build_time_utc\`).
5. Asserts \`GET /\` with \`Accept: text/plain\` returns the operator banner (text contains \"honeypot\").
6. Asserts \`POST /mcp\` Streamable HTTP \`initialize\` returns a JSON-RPC response with a \`protocolVersion\`.
7. Always dumps container logs on failure for postmortem.

## Why

PR #17 introduced \`build.rs\` that stamps git sha + build timestamp via env vars at compile time. The Dockerfile builder stage did not \`COPY build.rs\`, so the \`cargo build\` inside the image errored — but this only surfaced when I ran \`docker build\` locally during the deploy. Cargo CI was 7-of-7 green throughout because it never exercises the Dockerfile path.

PR #18 fixed it as a follow-up. With this CI job, that class of bug fails before merge.

## Test plan

- [x] Confirmed locally that the smoke assertions pass against \`honeymcp:0.6.0-rc.6\` (the image currently running in production).
- [ ] CI run on this PR will exercise the new job end-to-end.
- [ ] After merge: add \`docker build + smoke\` to required status checks via \`gh api\`.