### PR TITLE
ci: publish coverage to codecov + add badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,14 @@ jobs:
           name: coverage-lcov
           path: lcov.info
           retention-days: 14
+
+      # Codecov publishes the percentage so the README badge reflects current
+      # main, and PRs get a comment with the delta. Public repos do not
+      # require a token; the action fails *open* on flake (fail_ci_if_error
+      # is left default false) so a Codecov outage does not gate merges.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: rust
+          name: honeymcp-coverage

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # honeymcp
 
 [![CI](https://github.com/kosiorkosa47/honeymcp/actions/workflows/ci.yml/badge.svg)](https://github.com/kosiorkosa47/honeymcp/actions)
+[![codecov](https://codecov.io/gh/kosiorkosa47/honeymcp/branch/main/graph/badge.svg)](https://codecov.io/gh/kosiorkosa47/honeymcp)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 


### PR DESCRIPTION
## Summary

\`cargo-llvm-cov\` already produces \`lcov.info\` as a workflow artifact. This adds \`codecov/codecov-action@v5\` so the percentage gets a permanent home, the README gets a coverage badge, and PRs get an auto-generated delta comment.

## Why

Coverage was a "missing pro indicator" in the recent project audit — we generate the data but don't publish it. Adding the badge lets a drive-by reader see the number; the PR comment lets a reviewer see whether a change improves or regresses coverage.

## Notes

- No token required: codecov-action v5 detects public repos via OIDC.
- \`fail_ci_if_error\` is left at the action default (false) so a Codecov outage cannot block merges.
- Badge placed between CI and license badges in README.

## Test plan

- [ ] CI run on this PR exercises the upload step.
- [ ] Verify badge renders after first upload populates the project.