### PR TITLE
feat(personas): add vercel-admin and stripe-finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 I built honeymcp because there's no public record of what attackers actually send to MCP servers. The protocol is a year old, products using it ship weekly, and the usual web threat feeds don't cover this layer yet. So I wrote the sensor that collects it.
 
-It's one Rust binary. About 15 MB, SQLite on disk, fits in 256 MiB of RAM. You run it, point DNS, and it answers MCP handshakes the way a real server would. Personas are YAML. You pick one (I ship `postgres-admin` and `github-admin`) and anyone scanning the internet for MCP endpoints gets a full conversation with fake tools and canned responses.
+It's one Rust binary. About 15 MB, SQLite on disk, fits in 256 MiB of RAM. You run it, point DNS, and it answers MCP handshakes the way a real server would. Personas are YAML. I ship four out of the box (`postgres-admin`, `github-admin`, `vercel-admin`, `stripe-finance`) covering the surfaces attackers actually go after: source code, deployments, environment variables, financial data. Anyone scanning the internet for MCP endpoints gets a full conversation with fake tools and canned responses that hold up under multi-turn interrogation.
 
 What lands in SQLite: timestamp, method, IP, User-Agent, client name and version, the `Mcp-Session-Id` they used, the `MCP-Protocol-Version` they claimed, and a SHA-256 of the raw params so reruns correlate. Seven detectors tag events at write time, so you can grep for "prompt-injection traffic that also did tool-enumeration" without scanning the whole DB.
 

--- a/personas/stripe-finance.yaml
+++ b/personas/stripe-finance.yaml
@@ -1,0 +1,94 @@
+name: "stripe-finance"
+version: "2026-03.1"
+instructions: "Stripe revenue MCP for the acme-corp finance team. Read access to customers, charges, invoices, and subscriptions. Write actions (refunds, customer creation, subscription cancellation) require human-in-the-loop approval via Stripe dashboard. All API calls are visible in the Stripe Events log and the team audit trail."
+
+tools:
+  - name: "list_customers"
+    description: "List Stripe customers, optionally filtered by email or creation date range."
+    inputSchema:
+      type: object
+      properties:
+        email:
+          type: string
+        created_after:
+          type: string
+          description: "ISO 8601 timestamp"
+        limit:
+          type: integer
+          default: 20
+    response: "cus_OqPq1aBcDeFgHi   email=ada@acme-customer.com         name=Ada Lovelace        created=2024-08-12T11:04:00Z   subs=1   livemode=true\ncus_OqPq2zYxWvUtSr   email=alan.t@acme-customer.com      name=Alan Turing         created=2024-09-01T07:15:33Z   subs=2   livemode=true\ncus_OqPq3lMnOpQrSt   email=grace@acme-customer.com       name=Grace Hopper        created=2024-09-21T17:42:09Z   subs=1   livemode=true\ncus_OqPq4uVwXyZaBc   email=barbara@acme-customer.com     name=Barbara Liskov      created=2024-10-05T09:30:51Z   subs=3   livemode=true\ncus_OqPq5dEfGhIjKl   email=donald.k@acme-customer.com    name=Donald Knuth        created=2024-11-02T13:11:18Z   subs=1   livemode=true\n(214 customers total; 5 shown.)\n"
+
+  - name: "get_customer"
+    description: "Fetch a single customer by id, with subscriptions and default payment method."
+    inputSchema:
+      type: object
+      properties:
+        customer_id:
+          type: string
+      required: ["customer_id"]
+    response: "{\n  \"id\": \"cus_OqPq1aBcDeFgHi\",\n  \"email\": \"ada@acme-customer.com\",\n  \"name\": \"Ada Lovelace\",\n  \"livemode\": true,\n  \"created\": \"2024-08-12T11:04:00Z\",\n  \"balance\": 0,\n  \"currency\": \"usd\",\n  \"default_payment_method\": {\n    \"id\": \"pm_1OqXX****\",\n    \"type\": \"card\",\n    \"card\": {\"brand\": \"visa\", \"last4\": \"4242\", \"exp_month\": 11, \"exp_year\": 2028}\n  },\n  \"subscriptions\": [\n    {\"id\": \"sub_1OqYY****\", \"status\": \"active\", \"plan\": \"team-monthly\", \"amount\": 4900}\n  ],\n  \"address\": {\"country\": \"US\", \"postal_code\": \"94102\"}\n}\n"
+
+  - name: "list_charges"
+    description: "List Stripe charges, optionally scoped to a customer or status."
+    inputSchema:
+      type: object
+      properties:
+        customer:
+          type: string
+        status:
+          type: string
+          enum: ["succeeded", "pending", "failed"]
+        limit:
+          type: integer
+          default: 20
+    response: "ch_3OqA1xPq01abCDef   $49.00 USD   succeeded   cus_OqPq1aBcDeFgHi   2026-04-22T03:00:00Z   pi_3OqA1x****\nch_3OqA0wPq02ghIJkl   $99.00 USD   succeeded   cus_OqPq2zYxWvUtSr   2026-04-22T03:00:00Z   pi_3OqA0w****\nch_3OqA0vPq03mnOPqr   $49.00 USD   succeeded   cus_OqPq3lMnOpQrSt   2026-04-22T03:00:00Z   pi_3OqA0v****\nch_3OqA0uPq04stUVwx   $49.00 USD   failed       cus_OqPq6gHiJkLmNo   2026-04-22T03:00:00Z   pi_3OqA0u****  err=card_declined\nch_3OqA0tPq05yzABcd   $199.00 USD  succeeded   cus_OqPq7pQrStUvWx   2026-04-21T15:42:00Z   pi_3OqA0t****\n"
+
+  - name: "list_subscriptions"
+    description: "List active subscriptions, optionally filtered by status or plan."
+    inputSchema:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["active", "canceled", "past_due", "all"]
+          default: "active"
+        plan:
+          type: string
+        limit:
+          type: integer
+          default: 20
+    response: "sub_1OqYY****  active     plan=team-monthly       cus_OqPq1aBcDeFgHi   $49.00 USD/mo   started=2024-08-12\nsub_2OqYZ****  active     plan=team-monthly       cus_OqPq2zYxWvUtSr   $49.00 USD/mo   started=2024-09-01\nsub_3OqYa****  active     plan=enterprise-annual  cus_OqPq3lMnOpQrSt   $9,900.00 USD/yr started=2024-09-21\nsub_4OqYb****  past_due   plan=team-monthly       cus_OqPq6gHiJkLmNo   $49.00 USD/mo   started=2025-01-14   3 retries\nsub_5OqYc****  canceled   plan=team-monthly       cus_OqPq8hOrIzNeYa   $49.00 USD/mo   ended=2026-03-01\n"
+
+  - name: "search_invoices"
+    description: "Search invoices by query (customer email, amount, status)."
+    inputSchema:
+      type: object
+      properties:
+        query:
+          type: string
+          description: "Stripe Search query, e.g. 'status:open' or 'customer:cus_OqPq1aBcDeFgHi'"
+      required: ["query"]
+    response: "in_1OqZZ01****   open       $49.00 USD   cus_OqPq1aBcDeFgHi   due=2026-05-12\nin_1OqZZ02****   paid       $99.00 USD   cus_OqPq2zYxWvUtSr   paid=2026-04-22\nin_1OqZZ03****   void       $49.00 USD   cus_OqPq6gHiJkLmNo   voided=2026-04-12  reason=requested_by_customer\nin_1OqZZ04****   paid       $9,900.00 USD cus_OqPq3lMnOpQrSt  paid=2024-09-21\n"
+
+  - name: "get_balance"
+    description: "Return the current Stripe account balance and pending payouts."
+    inputSchema:
+      type: object
+      properties: {}
+    response: "{\n  \"livemode\": true,\n  \"available\": [\n    {\"amount\": 14723408, \"currency\": \"usd\"}\n  ],\n  \"pending\": [\n    {\"amount\": 318900, \"currency\": \"usd\"}\n  ],\n  \"connect_reserved\": [],\n  \"next_payout_at\": \"2026-04-26T08:00:00Z\",\n  \"payout_schedule\": \"daily\"\n}\n"
+
+  - name: "create_refund"
+    description: "Issue a refund against a charge. Requires human-in-the-loop approval via the Stripe dashboard before the refund actually executes."
+    inputSchema:
+      type: object
+      properties:
+        charge_id:
+          type: string
+        amount:
+          type: integer
+          description: "Refund amount in the smallest currency unit (cents). Defaults to full refund."
+        reason:
+          type: string
+          enum: ["duplicate", "fraudulent", "requested_by_customer"]
+      required: ["charge_id"]
+    response: "{\n  \"id\": \"re_pending_3OqA1x****\",\n  \"status\": \"pending_approval\",\n  \"charge\": \"<as supplied>\",\n  \"amount\": null,\n  \"reason\": \"<as supplied>\",\n  \"approval_url\": \"https://dashboard.stripe.com/refunds/pending/re_pending_3OqA1x\",\n  \"audit\": {\n    \"action\": \"refund.requested\",\n    \"actor\": \"<calling MCP client>\",\n    \"recorded\": true\n  },\n  \"note\": \"This refund is queued. A finance owner must approve in the Stripe dashboard before funds move. The MCP server cannot bypass this gate.\"\n}\n"

--- a/personas/vercel-admin.yaml
+++ b/personas/vercel-admin.yaml
@@ -1,0 +1,108 @@
+name: "vercel-admin"
+version: "1.7.4"
+instructions: "Vercel deployments MCP for the acme-corp team. Manage projects, deployments, environment variables, and preview URLs. All write actions are recorded in the Vercel team audit log; environment variable reads are scoped to the calling user's project access."
+
+tools:
+  - name: "list_teams"
+    description: "List Vercel teams the authenticated user belongs to."
+    inputSchema:
+      type: object
+      properties: {}
+    response: "team_id=team_acme01     name=acme-corp           plan=enterprise   members=42  created=2024-03-12T08:14:00Z\nteam_id=team_acme02     name=acme-corp-labs      plan=pro          members=8   created=2025-09-01T11:42:00Z\nteam_id=team_acmehol    name=acme-holdings       plan=enterprise   members=119 created=2023-07-22T15:08:00Z\n"
+
+  - name: "list_projects"
+    description: "List Vercel projects in a team."
+    inputSchema:
+      type: object
+      properties:
+        team_id:
+          type: string
+          description: "Team identifier, e.g. team_acme01"
+        limit:
+          type: integer
+          default: 20
+      required: ["team_id"]
+    response: "prj_internal_api          framework=nextjs        latest=dpl_8h9j2k_prod   domain=api.acme-corp.com\nprj_billing_dashboard     framework=nextjs        latest=dpl_3a4b5c_prod   domain=billing.acme-corp.com\nprj_customer_portal       framework=nextjs        latest=dpl_7f8g9h_prod   domain=app.acme-corp.com\nprj_marketing_site        framework=astro         latest=dpl_2x3y4z_prod   domain=acme-corp.com\nprj_status_page           framework=nextjs        latest=dpl_5p6q7r_prod   domain=status.acme-corp.com\nprj_internal_admin        framework=nextjs        latest=dpl_9w8e7r_prv    domain=admin.acme-corp.internal\nprj_pdf_renderer          framework=other         latest=dpl_4t5y6u_prod   domain=pdf-render.acme-corp.com\nprj_webhook_relay         framework=other         latest=dpl_1q2w3e_prod   domain=hooks.acme-corp.com\n"
+
+  - name: "get_project"
+    description: "Get full metadata for one Vercel project."
+    inputSchema:
+      type: object
+      properties:
+        project_id:
+          type: string
+        team_id:
+          type: string
+      required: ["project_id", "team_id"]
+    response: "{\n  \"id\": \"prj_internal_api\",\n  \"name\": \"internal-api\",\n  \"framework\": \"nextjs\",\n  \"node_version\": \"22.x\",\n  \"git_provider\": \"github\",\n  \"git_repo\": \"acme-corp/internal-api\",\n  \"production_branch\": \"main\",\n  \"build_command\": \"pnpm build\",\n  \"output_directory\": \".next\",\n  \"domains\": [\"api.acme-corp.com\", \"api-preview.acme-corp.com\"],\n  \"latest_deployment\": {\n    \"id\": \"dpl_8h9j2k_prod\",\n    \"url\": \"internal-api-acme-corp.vercel.app\",\n    \"state\": \"READY\",\n    \"target\": \"production\",\n    \"created_at\": \"2026-04-22T09:31:14Z\"\n  },\n  \"protection\": {\"password\": false, \"sso\": \"team-only\"}\n}\n"
+
+  - name: "list_deployments"
+    description: "List recent deployments for a project."
+    inputSchema:
+      type: object
+      properties:
+        project_id:
+          type: string
+        target:
+          type: string
+          enum: ["production", "preview"]
+        limit:
+          type: integer
+          default: 20
+      required: ["project_id"]
+    response: "dpl_8h9j2k_prod   READY      production   main             commit=4f9c1a2  built=4m12s  created=2026-04-22T09:31:14Z\ndpl_7g6h5j_prev   READY      preview      feat/auth-rev   commit=8b3d4e5  built=3m44s  created=2026-04-22T08:01:09Z\ndpl_3a4b5c_prev   READY      preview      chore/deps     commit=1a2b3c4  built=2m51s  created=2026-04-21T17:18:33Z\ndpl_9z8y7x_prev   ERROR      preview      feat/billing    commit=5e6f7g8  built=1m07s  created=2026-04-21T13:02:55Z  err=BUILD_FAILED\ndpl_5p6q7r_prod   READY      production   main             commit=2c3d4e5  built=4m08s  created=2026-04-20T15:44:21Z\n"
+
+  - name: "get_deployment_logs"
+    description: "Fetch build/runtime logs for a deployment by id."
+    inputSchema:
+      type: object
+      properties:
+        deployment_id:
+          type: string
+        kind:
+          type: string
+          enum: ["build", "runtime"]
+          default: "build"
+      required: ["deployment_id"]
+    response: "[2026-04-22T09:27:02.118Z] Cloning github.com/acme-corp/internal-api...\n[2026-04-22T09:27:08.044Z] Running build in Washington, D.C., USA (East) - iad1\n[2026-04-22T09:27:08.901Z] Detected Next.js v15.4.2\n[2026-04-22T09:27:09.220Z] Installing dependencies via pnpm...\n[2026-04-22T09:27:41.118Z] > pnpm build\n[2026-04-22T09:27:42.018Z]    Linting and checking validity of types ...\n[2026-04-22T09:28:14.553Z]    Creating an optimized production build ...\n[2026-04-22T09:30:51.872Z]    Generating static pages (124/124)\n[2026-04-22T09:31:11.401Z] Build completed in 3m44s\n[2026-04-22T09:31:14.118Z] Deployment ready https://internal-api-acme-corp.vercel.app\n"
+
+  - name: "list_env_vars"
+    description: "List environment variable keys (values are masked unless reveal=true and caller has owner role)."
+    inputSchema:
+      type: object
+      properties:
+        project_id:
+          type: string
+        target:
+          type: string
+          enum: ["production", "preview", "development"]
+          default: "production"
+        reveal:
+          type: boolean
+          default: false
+      required: ["project_id"]
+    response: "DATABASE_URL=postgres://app:****@db.internal:5432/app\nREDIS_URL=redis://****@cache.internal:6379/0\nAUTH0_DOMAIN=acme-corp.eu.auth0.com\nAUTH0_CLIENT_ID=DkH2****qX91\nAUTH0_CLIENT_SECRET=****\nSTRIPE_SECRET_KEY=sk_live_****\nSTRIPE_WEBHOOK_SECRET=whsec_****\nSENTRY_DSN=https://****@o123.ingest.sentry.io/456\nVERCEL_ENV=production\nNEXT_PUBLIC_API_BASE=https://api.acme-corp.com\nNEXT_PUBLIC_SENTRY_DSN=https://****@o123.ingest.sentry.io/789\n# 11 keys total. Values are masked because reveal=false. Pass reveal=true and confirm OWNER role to read literal values; this action is logged to the team audit log.\n"
+
+  - name: "redeploy"
+    description: "Trigger a new deployment for an existing project from the production branch HEAD."
+    inputSchema:
+      type: object
+      properties:
+        project_id:
+          type: string
+        target:
+          type: string
+          enum: ["production", "preview"]
+          default: "production"
+      required: ["project_id"]
+    response: "{\n  \"id\": \"dpl_pending_xQq91Z\",\n  \"state\": \"BUILDING\",\n  \"target\": \"production\",\n  \"queued_at\": \"2026-04-25T18:42:11Z\",\n  \"audit\": {\n    \"action\": \"deployment.trigger\",\n    \"actor\": \"<calling user>\",\n    \"recorded\": true\n  }\n}\n"
+
+  - name: "search_documentation"
+    description: "Search the Vercel public documentation index."
+    inputSchema:
+      type: object
+      properties:
+        query:
+          type: string
+      required: ["query"]
+    response: "vercel.com/docs/agent-resources/vercel-mcp        Use Vercel's MCP server\nvercel.com/docs/projects/environment-variables    Environment Variables\nvercel.com/docs/deployments/troubleshoot          Troubleshoot a deployment\nvercel.com/docs/edge-network/headers              Edge Network: Headers\nvercel.com/docs/security/audit-log                Team audit log\n"


### PR DESCRIPTION
## Summary

Two new personas covering attack surfaces the existing \`github-admin\` and \`postgres-admin\` don't:

- **\`vercel-admin\`** (8 tools) — modelled on the official \`mcp.vercel.com\` surface (teams, projects, deployments, deployment logs, env vars, redeploy, doc search). Env vars are masked by default with a \`reveal=true\` escape hatch.
- **\`stripe-finance\`** (7 tools) — customers, charges, subscriptions, invoices, balance, and a \`create_refund\` that explicitly tells the caller the dashboard gate cannot be bypassed.

## Why

Research: \`mcp.vercel.com\` shipped publicly with team auth (Feb 2026), and Stripe MCP is the highest-value financial surface in the 2026 ecosystem. Env-var theft and financial PII are the attacker priorities the existing personas don't model.

## Realism notes

- Vercel canned responses use plausible deployment IDs (\`dpl_8h9j2k_prod\`), build log timestamps that match Vercel's actual log format, and env var keys that any production Next.js team will recognise (DATABASE_URL, AUTH0_*, STRIPE_*, SENTRY_DSN).
- Stripe canned responses use customer ID format (\`cus_*\`), payment intent format (\`pi_3*\`), invoice format (\`in_1*\`), and the same ISO 8601 timestamps Stripe's own API emits.
- Both personas mention audit logs in their \`instructions\` so a careful attacker thinks twice about destructive calls — same defensive-by-default tone as a real enterprise MCP integration.

## Follow-up issues

Three more personas left intentionally as \`good first issue\` tickets so external contributors can pick them up:

1. \`figma-dev\` (Dev Mode design context, variable defs)
2. \`cloudflare-edge\` (DNS + Workers + R2 + Zero Trust)
3. \`linear-pm\` (issues, projects, cycles)

## Test plan

- [x] \`cargo build --release\`
- [x] Local smoke: vercel-admin returns 8 tools, stripe-finance returns 7
- [x] \`cargo fmt --check\` clean
- [ ] CI \`docker build + smoke\` will exercise the loader against the existing default persona