### PR TITLE
ci: pass CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,5 @@ jobs:
           files: lcov.info
           flags: rust
           name: honeymcp-coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
Wires the CODECOV_TOKEN repo secret (already set) into the existing codecov-action step. Avoids tokenless rate-limits and unblocks the badge populating after the next main push. `fail_ci_if_error: false` left explicit so a Codecov outage cannot block merges.