### PR TITLE
docs(readme): switch codecov badge to shields proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # honeymcp
 
 [![CI](https://github.com/kosiorkosa47/honeymcp/actions/workflows/ci.yml/badge.svg)](https://github.com/kosiorkosa47/honeymcp/actions)
-[![codecov](https://codecov.io/gh/kosiorkosa47/honeymcp/branch/main/graph/badge.svg)](https://codecov.io/gh/kosiorkosa47/honeymcp)
+[![codecov](https://img.shields.io/codecov/c/github/kosiorkosa47/honeymcp/main?logo=codecov&label=coverage)](https://app.codecov.io/github/kosiorkosa47/honeymcp)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 


### PR DESCRIPTION
GitHub Camo cached the pre-token `unknown` SVG. Shields reads codecov API on each fetch so the badge picks up the live value (currently 78%). Same destination URL on click. No workflow change.