### PR TITLE
release(0.6.0): cut stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-27
+
+This is the first stable cut. The release closes the gap between
+`0.6.0-rc.1` (the smoke-test cut on 2026-04-24) and the production
+deploy that has been running on the Singapore Lightsail box since
+2026-04-25 19:06 UTC. 36+ hours of soak under live Censys traffic and
+operator validation, no restarts, no panic, no drift on `/healthz`.
+
+The signed GHCR image (`ghcr.io/kosiorkosa47/honeymcp:0.6.0`) is the
+first one I'd recommend pulling rather than building locally; it carries
+a real `git_sha` (the in-image build context now includes the workspace
+checkout that `release.yml` performs) and is signed via cosign keyless
+OIDC, with SPDX + CycloneDX SBOMs attested to the image digest.
+
 ### Added - operator surface
 
 - **`/version` endpoint** (#17). `GET /version` returns JSON with crate name,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "honeymcp"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeymcp"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Open-source MCP (Model Context Protocol) honeypot for collecting threat intelligence"


### PR DESCRIPTION
## Summary

Bumps \`Cargo.toml\` from \`0.6.0-rc.1\` to \`0.6.0\` and graduates the \`[Unreleased]\` block in \`CHANGELOG.md\` to a stable \`[0.6.0] - 2026-04-27\` entry with a release note.

## Soak

The 0.6.0-rc.7 image has been running on the production VPS since 2026-04-25 19:06 UTC. That is 36+ hours under live Censys traffic plus operator validation. Healthcheck never flipped, no restart, no panic. RSS stable under the 256 MiB compose cap.

## What ships in 0.6.0 vs 0.6.0-rc.1

11 PRs landed since rc.1. Key items:

- \`/version\` endpoint with build-time provenance (#17, #18)
- \`is_operator\` flag + \`/stats?include_operator=true\` filter (#26)
- vercel-admin and stripe-finance personas (#27)
- docker build + smoke CI job, promoted to required (#23)
- Codecov publishing + badge (#25, #31, #32)
- CODEOWNERS + 3 good-first-issues + 3 persona follow-up issues (#19, #20, #21, #22, #28, #29, #30)
- OpenTelemetry stack atomic bump 0.27 → 0.31 (#33)
- Honest week-1 blog corrigendum (#24)

Full breakdown in \`CHANGELOG.md\`.

## After merge

\`\`\`bash
git tag -s v0.6.0 -m "honeymcp 0.6.0"
git push origin v0.6.0
\`\`\`

\`release.yml\` will then:

1. Build cross-compiled binaries for 5 targets, package + checksum.
2. Build, push, and cosign-sign the GHCR multi-arch image (\`ghcr.io/kosiorkosa47/honeymcp:0.6.0\`).
3. Generate SPDX + CycloneDX SBOMs, attest them to the image digest.
4. Cut the GitHub Release with binaries and SBOMs attached.

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` 6/6 pass on the workspace
- [ ] CI on this PR runs the docker build + smoke job against the new version string
- [ ] After merge: tag triggers release.yml; verify cosign verify works against the resulting image digest