### PR TITLE
docs: log dashboard v2 in CHANGELOG + reword README dashboard mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 ## [Unreleased]
 
+### Added - dashboard v2 foundation
+
+- **Server-rendered dashboard at `/dashboard`** (#42). Drops the legacy
+  single-file vanilla-JS embed (440 lines polling `/stats` every 5 s) in
+  favour of a `minijinja` server-side surface with htmx + Alpine.js for
+  small client-side state. All assets (templates, CSS, htmx, alpine) ship
+  inside the binary via `include_str!`; no `node_modules`, no separate
+  frontend repo, no asset pipeline. The full design is in
+  [`docs/dashboard-v2-design.md`](docs/dashboard-v2-design.md).
+
+- **Attack Story Timeline** is the new primary view. Sessions, not
+  requests, are the unit of analysis. Each session card carries an
+  external/operator dot, an event count, a detector count, and the
+  last-seen IP and User-Agent. Expanding a card shows every event in
+  the session ordered newest-first with detector strikes inline and a
+  collapsible params preview.
+
+- **MCP Sequence Diagram** at `/dashboard/sequence/<id>.svg`. Renders a
+  per-session protocol diagram server-side as standalone SVG: client
+  lifeline left, persona right, one arrow per JSON-RPC frame, tool
+  name pill on every `tools/call`, red strike on the right margin where
+  a detector fired. This is the visualisation no other honeypot
+  dashboard ships and is the headline component of the rewrite.
+
+- **Build provenance footer** on every dashboard page, hydrated from
+  `/version`. Shows the running version, 12-char git short sha,
+  RFC3339 build time, and a `cosign verified` marker linking to the
+  GHCR-signed image.
+
+- **Honest-by-default counters.** Every count on the dashboard is the
+  external corpus by default; the toggle is a real query parameter
+  (`?include_operator=true`) so URLs are shareable and the methodology
+  stays visible.
+
+- **16 unit tests** for dashboard helpers (XML escaping, MCP method
+  classification, tool-name parsing, detection JSON parsing, relative
+  time formatting, URL encoding, session grouping, sequence SVG
+  shape, IP resolution with XFF precedence). Patch coverage on the new
+  module rose from 0 to ~70%.
+
+### Changed
+
+- `HttpTransport` gains `with_logger()`. The dashboard surface mounts
+  only when both stats and logger are present; otherwise `/dashboard`
+  returns 503 with a clear message rather than serving an empty UI.
+- `Logger::recent_events_with_detections` is the single query feeding
+  both the timeline and the SVG path; it returns a wide `RawEventRow`
+  with the detection JSON aggregated server-side so handlers don't fan
+  out into multiple SQL paths.
+- README link to the Model Context Protocol now points at the
+  `/docs/getting-started/intro` page instead of the raw spec (#40).
+
+### Notes
+
+- The legacy `src/dashboard.html` embed has been removed. Operators on
+  `0.6.0` will lose the v1 dashboard at deploy time but gain the v2
+  one with no compose changes; the route stays at `/dashboard`.
+- Six remaining dashboard components from the design doc (Sankey,
+  detector co-occurrence heatmap, live SSE feed, geo-IP pulse map,
+  full provenance panel, methodology sidebar) are tracked as
+  follow-ups and ship incrementally without further breaking
+  changes.
+
 ## [0.6.0] - 2026-04-27
 
 This is the first stable cut. The release closes the gap between

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It's one Rust binary. About 15 MB, SQLite on disk, fits in 256 MiB of RAM. You r
 
 What lands in SQLite: timestamp, method, IP, User-Agent, client name and version, the `Mcp-Session-Id` they used, the `MCP-Protocol-Version` they claimed, and a SHA-256 of the raw params so reruns correlate. Seven detectors tag events at write time, so you can grep for "prompt-injection traffic that also did tool-enumeration" without scanning the whole DB.
 
-It's not a proxy. It won't protect your production MCP server. It's a trap you put on the internet to learn from. `GET /` returns a plain-text banner saying exactly that with a GDPR erasure contact. `GET /dashboard` shows the live feed. No admin panel, no write path exposed to the network.
+It's not a proxy. It won't protect your production MCP server. It's a trap you put on the internet to learn from. `GET /` returns a plain-text banner saying exactly that with a GDPR erasure contact. `GET /dashboard` is a server-rendered analyst surface (Attack Story Timeline grouped per session + per-session MCP Sequence Diagram SVG at `/dashboard/sequence/<id>.svg`); operator traffic is filtered out by default with a `?include_operator=true` toggle. No admin panel, no write path exposed to the network.
 
 `honeymcp-probes` is the second binary in this crate. It fires the same 13 payloads the detectors are tuned for, so you can audit your own MCP server without standing up a honeypot. Same codebase, same taxonomy.
 
@@ -41,7 +41,7 @@ MCP is a young protocol with a rapidly growing attack surface: **tool poisoning*
 - Loads a **persona** from YAML - server name, version, instructions, and a list of fake tools with canned responses.
 - Ships **four personas** out of the box: `postgres-admin`, `github-admin`, `vercel-admin`, `stripe-finance` - covering source code, deployments, environment variables, and financial data.
 - Ships as a **Docker image** for one-command deploy; release builds are cosign-keyless-signed with SPDX + CycloneDX SBOMs attached.
-- Serves an **operator banner** (research-honeypot disclosure + GDPR contact) at `GET /`, dashboard at `/dashboard`.
+- Serves an **operator banner** (research-honeypot disclosure + GDPR contact) at `GET /` and a server-rendered **analyst dashboard** at `/dashboard` (Attack Story Timeline + per-session MCP Sequence Diagram, all assets bundled in the binary, design in [`docs/dashboard-v2-design.md`](docs/dashboard-v2-design.md)).
 - Runs **seven threat detectors** (prompt injection, shell injection, CVE-2025-59536-class hook injection, secret exfil, unicode anomaly, recon, tool enumeration) on every request, tagging events at write time.
 - Logs every request/response to **SQLite** (primary, queryable) and optionally mirrors to **JSONL** (grep/jq-friendly), including timestamp, method, SHA-256 of params, raw params, client name/version, session id, transport, remote address, and User-Agent.
 - **Tags operator traffic** at write time (`is_operator` column). `/stats` excludes probes and validation curls by default so any number a third party reads is the external-only corpus; pass `?include_operator=true` to fold them back in.


### PR DESCRIPTION
Adds an `[Unreleased]` block above `[0.6.0]` covering the dashboard v2 rewrite that landed in #42 (foundation + Attack Story Timeline + MCP Sequence Diagram + 16 unit tests). README dashboard mention now describes the new surface instead of the v1 'live feed' phrasing.