### PR TITLE
fix(dashboard): swap session card to native <details>/<summary>

### DIFF
--- a/src/dashboard/static/dashboard.css
+++ b/src/dashboard/static/dashboard.css
@@ -143,7 +143,9 @@ body {
 }
 .hm-h2-sub { color: var(--hm-fg-dim); font-size: 12px; margin: 0 0 16px; }
 
-/* Session card */
+/* Session card. Backed by a native <details>/<summary> so expand/collapse
+ * works without any JS at all — Alpine handles the operator toggle and the
+ * provenance footer, but the timeline itself is a no-JS surface. */
 .hm-session {
   background: var(--hm-bg-elev);
   border: 1px solid var(--hm-rule);
@@ -153,6 +155,11 @@ body {
   transition: border-color 0.18s;
 }
 .hm-session:hover { border-color: var(--hm-rule-strong); }
+
+/* Strip the default disclosure triangle from the summary; we render our
+ * own visual signal via the dot + last-seen meta line. */
+.hm-session > summary { list-style: none; }
+.hm-session > summary::-webkit-details-marker { display: none; }
 
 .hm-session-head {
   display: grid;

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -58,8 +58,8 @@
   </p>
 
   {% for session in sessions %}
-  <article class="hm-session" x-data="{ open: {{ 'true' if loop.first else 'false' }} }">
-    <header class="hm-session-head" @click="open = !open">
+  <details class="hm-session" {% if loop.first %}open{% endif %}>
+    <summary class="hm-session-head">
       <div class="hm-session-id">
         <span class="hm-session-dot hm-session-dot--{{ 'operator' if session.is_operator else 'external' }}"></span>
         <code>{{ session.session_id }}</code>
@@ -75,13 +75,13 @@
         <span class="hm-ua">{{ session.user_agent }}</span>
         <time datetime="{{ session.last_seen_iso }}">{{ session.last_seen_human }}</time>
       </div>
-    </header>
+    </summary>
 
     <a class="hm-session-sequence-link" href="/dashboard/sequence/{{ session.session_id_url }}.svg" target="_blank">
       open MCP sequence diagram
     </a>
 
-    <ol class="hm-session-events" x-show="open" x-transition>
+    <ol class="hm-session-events">
       {% for ev in session.events %}
       <li class="hm-event hm-event--{{ ev.method_class }}">
         <time datetime="{{ ev.iso }}">{{ ev.relative }}</time>
@@ -109,7 +109,7 @@
       </li>
       {% endfor %}
     </ol>
-  </article>
+  </details>
   {% endfor %}
 </section>
 


### PR DESCRIPTION
Alpine x-show on the events list raced the defer-loaded bundle on real production loads — the list rendered hidden until Alpine hydrated, and clicking the header before that did nothing. Symptoms looked like 'timeline broken' though the data was always there. Native <details>/<summary> handles expand/collapse with zero JS; first session opens by default via the standard `open` attribute. Operator toggle and provenance footer remain Alpine-driven.