### PR TITLE
test: property-based suites for parser, detectors, persona loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1011,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "proptest",
  "regex",
  "reqwest",
  "rusqlite",
@@ -1754,6 +1770,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1825,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -1924,6 +1965,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2127,6 +2177,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2892,6 +2954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,6 +3045,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util", "sync", "fs", "test-util"] }
 wiremock = "0.6"
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+# Property-based tests live under `tests/property_*.rs`. The fixed seed in
+# proptest/proptest-regressions/ keeps a known counter-example replayed
+# on every run so once a bug is captured it stays captured.
+proptest = "1"
 
 [[bench]]
 name = "detectors"

--- a/src/detect/shell_injection.rs
+++ b/src/detect/shell_injection.rs
@@ -52,8 +52,19 @@ impl Detector for ShellInjectionDetector {
         let params = ctx.entry.params.as_ref()?;
         let body = params.to_string();
         let m = pattern().find(&body)?;
-        let start = m.start().saturating_sub(16);
-        let end = (m.end() + 16).min(body.len());
+        // Snap excerpt window to UTF-8 char boundaries so attacker-supplied
+        // multi-byte sequences (emoji, surrogate-pair lookalikes, RTL marks)
+        // can't trigger a slice-on-non-boundary panic. Found by proptest.
+        let raw_start = m.start().saturating_sub(16);
+        let raw_end = (m.end() + 16).min(body.len());
+        let mut start = raw_start;
+        while start > 0 && !body.is_char_boundary(start) {
+            start -= 1;
+        }
+        let mut end = raw_end;
+        while end < body.len() && !body.is_char_boundary(end) {
+            end += 1;
+        }
         let excerpt = &body[start..end];
         Some(Detection {
             detector: "shell_injection_patterns",

--- a/tests/property_detectors.proptest-regressions
+++ b/tests/property_detectors.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc db8b2ec88ced1aef316b12f63f0714afff8a8a399bb77c96b830a5d3a630ebf9 # shrinks to tool_name = "", arguments = Array [String("𐀀   aࠀ𐀀A ``")]
+cc 7a5e3a4eaa82185a1b5ba204de21470ae88305f9140f8dcdc9b5633be7ee1bc3 # shrinks to params = Array [String("``\0a¡𐀀𐀀")], method = "initialize", calls = 0, list_count = 0, call_count = 0

--- a/tests/property_detectors.rs
+++ b/tests/property_detectors.rs
@@ -1,0 +1,127 @@
+//! Property: every detector returns cleanly for any input shape.
+//!
+//! Why: detectors run on attacker-controlled `params`. A panic in any
+//! detector means the dispatcher never logs the event, never returns a
+//! response, and the operator notices only via crash-loop. The test
+//! suite has scripted inputs; this property covers everything outside
+//! that scripted set.
+//!
+//! What it asserts: `Registry::analyze_all` never panics on any
+//! serializable JSON value, on any reasonable string method name, with
+//! any combination of session-stat counters.
+
+use honeymcp::detect::{DetectionContext, Registry, SessionStats};
+use honeymcp::logger::{hash_params, LogEntry};
+use proptest::prelude::*;
+use serde_json::{json, Value};
+
+/// proptest strategy that produces "json-shaped" values up to a bounded
+/// depth. We don't try to cover every Value variant pessimally; the goal
+/// is to hit the shapes detectors actually iterate over (objects with
+/// nested arrays, strings of varying length).
+fn arb_json_value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        any::<i64>().prop_map(Value::from),
+        ".{0,256}".prop_map(Value::String),
+    ];
+    leaf.prop_recursive(
+        4,  // max depth
+        64, // max total nodes
+        16, // max items per collection
+        |inner| {
+            prop_oneof![
+                proptest::collection::vec(inner.clone(), 0..16).prop_map(Value::Array),
+                proptest::collection::hash_map(".{0,32}", inner, 0..16)
+                    .prop_map(|map| Value::Object(map.into_iter().collect())),
+            ]
+        },
+    )
+}
+
+fn make_entry(method: String, params: Value) -> LogEntry {
+    LogEntry {
+        timestamp_ms: 0,
+        method,
+        params_hash: hash_params(&Some(params.clone())),
+        params: Some(params),
+        client_name: Some("prop".into()),
+        client_version: Some("0".into()),
+        session_id: "prop-session".into(),
+        response_summary: String::new(),
+        transport: Some("http".into()),
+        remote_addr: Some("203.0.113.7:51000".into()),
+        user_agent: Some("prop/1.0".into()),
+        client_meta: None,
+        is_operator: false,
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // Detector pipeline is regex-heavy; 256 cases is enough to surface
+        // catastrophic-backtracking shapes without making the suite slow.
+        cases: 256,
+        ..ProptestConfig::default()
+    })]
+
+    /// Random JSON params, real method name. Detector pipeline must not
+    /// panic regardless of how deeply nested or how oddly typed the input is.
+    #[test]
+    fn analyze_all_never_panics_on_random_params(
+        params in arb_json_value(),
+        method in proptest::sample::select(vec![
+            "initialize".to_string(),
+            "tools/list".to_string(),
+            "tools/call".to_string(),
+            "notifications/initialized".to_string(),
+            "ping".to_string(),
+        ]),
+        calls in 0u32..100,
+        list_count in 0u32..100,
+        call_count in 0u32..100,
+    ) {
+        let entry = make_entry(method, params);
+        let stats = SessionStats {
+            calls_in_session: calls,
+            tools_list_count: list_count,
+            tools_call_count: call_count,
+        };
+        let ctx = DetectionContext { entry: &entry, stats: &stats };
+        let registry = Registry::default_enabled();
+        let _detections = registry.analyze_all(&ctx);
+    }
+
+    /// Adversarial method names (long, unicode-heavy, control chars) must
+    /// not crash the detectors that look at `entry.method` directly.
+    #[test]
+    fn analyze_all_never_panics_on_adversarial_method(
+        method in ".{0,1024}",
+    ) {
+        let entry = make_entry(method, json!({}));
+        let stats = SessionStats::default();
+        let ctx = DetectionContext { entry: &entry, stats: &stats };
+        let registry = Registry::default_enabled();
+        let _detections = registry.analyze_all(&ctx);
+    }
+
+    /// Tools/call with random tool names and random arg shapes — covers
+    /// the hot path for production attacker traffic.
+    #[test]
+    fn tools_call_with_random_arguments_never_panics(
+        tool_name in ".{0,128}",
+        arguments in arb_json_value(),
+    ) {
+        let params = json!({"name": tool_name, "arguments": arguments});
+        let entry = make_entry("tools/call".into(), params);
+        let stats = SessionStats {
+            calls_in_session: 1,
+            tools_list_count: 0,
+            tools_call_count: 1,
+        };
+        let ctx = DetectionContext { entry: &entry, stats: &stats };
+        let registry = Registry::default_enabled();
+        let _detections = registry.analyze_all(&ctx);
+    }
+}

--- a/tests/property_jsonrpc_parser.rs
+++ b/tests/property_jsonrpc_parser.rs
@@ -1,0 +1,63 @@
+//! Property: the JSON-RPC parser never panics, regardless of input.
+//!
+//! Why this is load-bearing for a honeypot: the parser is the first line of
+//! code attacker bytes touch. A panic here = process death = honeypot
+//! offline = corpus loss. We accept "Result::Err" for any malformed input,
+//! never an unwind.
+
+use honeymcp::protocol::JsonRpcRequest;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // 1024 cases per CI run; high enough to catch the obvious classes
+        // (UTF-8 boundary cases, deeply nested arrays, alternating quotes)
+        // and low enough to keep the property suite under 10 seconds.
+        cases: 1024,
+        ..ProptestConfig::default()
+    })]
+
+    /// Arbitrary bytes never panic the parser.
+    #[test]
+    fn arbitrary_bytes_never_panic(bytes in proptest::collection::vec(any::<u8>(), 0..4096)) {
+        // We don't care whether the input parses; we only care that no
+        // input causes an unwind across the FFI-shaped boundary the parser
+        // sits on. serde_json::from_slice returns Result, so a Result::Err
+        // is the expected outcome for the vast majority of cases.
+        let _ = serde_json::from_slice::<JsonRpcRequest>(&bytes);
+    }
+
+    /// Arbitrary UTF-8 strings never panic the parser.
+    #[test]
+    fn arbitrary_utf8_never_panics(s in ".{0,4096}") {
+        let _ = serde_json::from_str::<JsonRpcRequest>(&s);
+    }
+
+    /// Deeply nested JSON arrays never panic before the recursion limit
+    /// kicks in. serde_json caps at 128 levels; anything deeper should
+    /// return Err, never overflow the stack.
+    #[test]
+    fn deeply_nested_arrays_return_err_not_panic(depth in 0usize..2048) {
+        let mut s = String::with_capacity(depth * 2);
+        for _ in 0..depth {
+            s.push('[');
+        }
+        for _ in 0..depth {
+            s.push(']');
+        }
+        let _ = serde_json::from_str::<JsonRpcRequest>(&s);
+    }
+
+    /// Well-formed but semantically nonsensical JSON-RPC (wrong jsonrpc
+    /// version, missing method, etc.) returns Err rather than panicking
+    /// inside any custom Deserialize impls we ship.
+    #[test]
+    fn well_formed_json_garbage_method(method in ".{0,256}", jsonrpc in ".{0,16}") {
+        let envelope = serde_json::json!({
+            "jsonrpc": jsonrpc,
+            "method": method,
+            "id": 1,
+        });
+        let _ = serde_json::from_value::<JsonRpcRequest>(envelope);
+    }
+}

--- a/tests/property_persona_loader.rs
+++ b/tests/property_persona_loader.rs
@@ -1,0 +1,47 @@
+//! Property: the persona YAML loader returns `Result::Err` for any
+//! malformed input rather than panicking.
+//!
+//! Why: an operator who misconfigures their persona file (typo, partial
+//! download, wrong YAML version) must get a clear error at startup, not
+//! a panic that kills the supervisor a thousand restarts later.
+
+use honeymcp::persona::Persona;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        ..ProptestConfig::default()
+    })]
+
+    /// Arbitrary UTF-8 fed straight into serde_yaml. We don't care
+    /// whether anything parses — we care that nothing panics.
+    #[test]
+    fn arbitrary_yaml_never_panics(s in ".{0,4096}") {
+        let _ = serde_yaml::from_str::<Persona>(&s);
+    }
+
+    /// YAML structures shaped like a persona but with random field
+    /// values. These hit the deserializer's per-field code paths in a
+    /// way the corpus-shaped test cases above don't.
+    #[test]
+    fn persona_shaped_yaml_never_panics(
+        name in "[a-z0-9-]{0,64}",
+        version in ".{0,32}",
+        instructions in ".{0,1024}",
+        tool_count in 0usize..32,
+    ) {
+        let mut yaml = format!("name: \"{}\"\nversion: \"{}\"\ninstructions: \"{}\"\ntools:\n",
+            name.replace('"', ""),
+            version.replace('"', ""),
+            instructions.replace('"', "").replace('\n', " "),
+        );
+        for i in 0..tool_count {
+            yaml.push_str(&format!(
+                "  - name: \"tool_{}\"\n    description: \"d\"\n    inputSchema:\n      type: object\n    response: \"r\"\n",
+                i,
+            ));
+        }
+        let _ = serde_yaml::from_str::<Persona>(&yaml);
+    }
+}


### PR DESCRIPTION
## Summary
- Three property suites (`tests/property_*.rs`) targeting JSON-RPC parser, detector pipeline, and persona YAML loader
- 1024 cases for parser, 256 cases for detectors and persona loader (256 keeps detector pipeline under 1s on M1 release build)
- Each suite asserts the *crash-resistance contract* of attacker-facing code paths: arbitrary input must return `Result::Err`, never panic

## Real bug found
The detector property suite immediately surfaced a **slice-on-non-char-boundary panic** in `src/detect/shell_injection.rs:57`. The regex match window used raw byte offsets (`m.start().saturating_sub(16)..(m.end() + 16).min(body.len())`) that landed inside multi-byte UTF-8 sequences (emoji, RTL marks, surrogate-pair lookalikes), causing `&body[start..end]` to panic.

Fixed by snapping both ends of the excerpt window to char boundaries via `is_char_boundary` walk-back/walk-forward. Counter-example shrunk by proptest is checked in under `tests/property_detectors.proptest-regressions` so the regression replays on every CI run.

## Why this matters operationally
A panic in any detector takes down the async dispatcher task, which means the honeypot stops logging events mid-session. Detectors run on attacker-controlled `params`, so the input distribution is exactly the one proptest covers and the existing scripted unit tests don't.

## Test plan
- [x] `cargo test --release --test property_jsonrpc_parser` — 4 cases pass
- [x] `cargo test --release --test property_detectors` — 3 cases pass after the shell_injection fix
- [x] `cargo test --release --test property_persona_loader` — 2 cases pass
- [x] Full `cargo test --release` green
- [x] `cargo clippy --release --tests --benches -- -D warnings` clean
- [ ] CI green on Linux + macOS