### PR TITLE
ci(fuzz): install cargo-fuzz from a prebuilt binary

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,8 +34,12 @@ jobs:
       - uses: actions/checkout@v6
 
       # libfuzzer requires nightly Rust because it relies on -Z sanitizer
-      # flags that aren't stabilized. Pinned via the dtolnay action.
+      # flags that aren't stabilized. cargo-fuzz also rebuilds std/core with
+      # the sanitizer via -Zbuild-std, which needs the rust-src component
+      # (the minimal profile omits it, yielding "can't find crate for core").
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,12 +34,8 @@ jobs:
       - uses: actions/checkout@v6
 
       # libfuzzer requires nightly Rust because it relies on -Z sanitizer
-      # flags that aren't stabilized. cargo-fuzz also rebuilds std/core with
-      # the sanitizer via -Zbuild-std, which needs the rust-src component
-      # (the minimal profile omits it, yielding "can't find crate for core").
+      # flags that aren't stabilized. Pinned via the dtolnay action.
       - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rust-src
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -59,8 +55,12 @@ jobs:
         with:
           tool: cargo-fuzz
 
+      # Force the gnu target. The prebuilt cargo-fuzz binary is the musl build,
+      # and cargo-fuzz otherwise infers the build target from its own triple —
+      # building for musl, whose static libc is incompatible with the address
+      # sanitizer (and whose std isn't installed on the runner).
       - name: Run ${{ matrix.target }} for 60s
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60
+        run: cargo +nightly fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=60
 
       # Upload any crash artifacts the run produced so we can debug failed
       # CI runs without re-running locally. Empty upload is fine — the

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -46,8 +46,14 @@ jobs:
           workspaces: |
             fuzz
 
+      # Install a prebuilt cargo-fuzz binary rather than building it from
+      # source. `cargo install --locked cargo-fuzz` started failing in CI when
+      # the latest nightly + a fresh dependency tree stopped compiling
+      # cargo-fuzz 0.13.2; a prebuilt binary sidesteps that toolchain coupling.
       - name: Install cargo-fuzz
-        run: cargo install --locked cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
 
       - name: Run ${{ matrix.target }} for 60s
         run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60


### PR DESCRIPTION
The fuzz-smoke job started failing on `cargo install --locked cargo-fuzz` — the latest nightly plus a fresh dependency tree stopped compiling cargo-fuzz 0.13.2 (no crash artifacts produced; the failure is in the tool install step, not the fuzz run). Switch to `taiki-e/install-action` for a prebuilt cargo-fuzz binary, decoupling the smoke job from cargo-fuzz's source build.