### PR TITLE
feat(telemetry): capture more headers + log non-MCP probes

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -254,14 +254,13 @@ impl Dispatcher {
         persona_name: &str,
         state: &SessionState,
     ) {
-        let ts = now_ms();
         let is_operator = self.operator.classify(
             ctx.user_agent.as_deref(),
             ctx.remote_addr.as_deref(),
             ctx.client_meta.as_ref(),
         );
         let entry = LogEntry {
-            timestamp_ms: ts,
+            timestamp_ms: now_ms(),
             method: req.method.clone(),
             params_hash: hash_params(&req.params),
             params: req.params.clone(),
@@ -276,7 +275,15 @@ impl Dispatcher {
             persona: Some(persona_name.to_string()),
             is_operator,
         };
+        self.persist_and_detect(entry, &state.stats).await;
+    }
 
+    /// Persist one event and run the detector registry against it. Shared by
+    /// the JSON-RPC dispatch path and the non-MCP probe path so both land in
+    /// the same events + detections tables (and the same dashboard + STIX
+    /// export).
+    async fn persist_and_detect(&self, entry: LogEntry, stats: &SessionStats) {
+        let ts = entry.timestamp_ms;
         let event_id = match self.logger.record(&entry).await {
             Ok(id) => Some(id),
             Err(e) => {
@@ -284,18 +291,18 @@ impl Dispatcher {
                 None
             }
         };
-        debug!(method = %req.method, transport = %ctx.transport, "logged event");
+        debug!(method = %entry.method, "logged event");
 
         if let Some(event_id) = event_id {
             if !self.registry.is_empty() {
                 let detections = self.registry.analyze_all(&DetectionContext {
                     entry: &entry,
-                    stats: &state.stats,
+                    stats,
                 });
                 if !detections.is_empty() {
                     info!(
                         count = detections.len(),
-                        method = %req.method,
+                        method = %entry.method,
                         "threat detections fired"
                     );
                     if let Err(e) = self
@@ -391,6 +398,47 @@ impl Handler for Dispatcher {
             }),
         }
     }
+
+    async fn log_probe(
+        &self,
+        ctx: RequestContext,
+        http_method: &str,
+        path: &str,
+        query: Option<String>,
+    ) {
+        let is_operator = self.operator.classify(
+            ctx.user_agent.as_deref(),
+            ctx.remote_addr.as_deref(),
+            ctx.client_meta.as_ref(),
+        );
+        // method="probe" (constant) keeps the dashboard's by-method grouping
+        // sane; the path/method/query live in params, where the existing
+        // detectors still see them (a `/.env` probe trips secret_exfil).
+        let params = serde_json::json!({
+            "http_method": http_method,
+            "path": path,
+            "query": query,
+        });
+        let entry = LogEntry {
+            timestamp_ms: now_ms(),
+            method: "probe".to_string(),
+            params_hash: hash_params(&Some(params.clone())),
+            params: Some(params),
+            client_name: None,
+            client_version: None,
+            session_id: ctx.session_id.clone(),
+            response_summary: format!("probe {http_method} {path}"),
+            transport: Some(ctx.transport.to_string()),
+            remote_addr: ctx.remote_addr.clone(),
+            user_agent: ctx.user_agent.clone(),
+            client_meta: ctx.client_meta.clone(),
+            // A probe didn't reach any persona — it hit a non-MCP path.
+            persona: None,
+            is_operator,
+        };
+        self.persist_and_detect(entry, &SessionStats::default())
+            .await;
+    }
 }
 
 #[cfg(test)]
@@ -468,5 +516,21 @@ tools:
         let resp = d.handle_request(req, ctx).await.expect("response");
         assert!(resp.error.is_some());
         assert_eq!(resp.error.unwrap().code, ErrorCode::MethodNotFound as i32);
+    }
+
+    #[tokio::test]
+    async fn log_probe_records_event_and_fires_detectors() {
+        let (d, _dir) = make_dispatcher().await;
+        let mut ctx = RequestContext::new("probe-1", "http");
+        ctx.remote_addr = Some("203.0.113.9:40000".into());
+        // A scan for a credential file. The path lands in params, where the
+        // secret_exfil detector still sees it.
+        d.log_probe(ctx, "GET", "/.env", None).await;
+
+        assert_eq!(d.logger.count_events(true).await.unwrap(), 1);
+        assert!(
+            d.logger.count_detections(true).await.unwrap() >= 1,
+            "a /.env probe should trip secret_exfil"
+        );
     }
 }

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -120,34 +120,68 @@ fn resolve_session_id(q: &SessionQuery, headers: &HeaderMap) -> String {
         .unwrap_or_else(generate_session_id)
 }
 
+/// High-signal headers captured into `client_meta` beyond the always-on trio
+/// (`x_forwarded_for`, `mcp_protocol_version`, `accept`). These carry
+/// attacker-supplied credentials (`authorization`, `x-api-key`), proxy/CDN
+/// provenance and the real client IP (`x-real-ip`, `cf-connecting-ip`,
+/// `cf-ipcountry`, `true-client-ip`, `via`), and browser/client fingerprint
+/// hints (`origin`, `referer`, `accept-language`, `accept-encoding`, `sec-*`).
+const CAPTURED_HEADERS: &[&str] = &[
+    "authorization",
+    "x-api-key",
+    "origin",
+    "referer",
+    "accept-language",
+    "accept-encoding",
+    "content-type",
+    "x-real-ip",
+    "cf-connecting-ip",
+    "cf-ipcountry",
+    "cf-ray",
+    "true-client-ip",
+    "x-client-ip",
+    "via",
+    "x-requested-with",
+    "sec-fetch-mode",
+    "sec-fetch-site",
+    "sec-ch-ua",
+];
+
+/// Per-header value cap so a hostile client can't bloat the JSONB column.
+const MAX_HEADER_VALUE_LEN: usize = 512;
+
 fn header_meta(headers: &HeaderMap) -> (Option<String>, Option<Value>) {
     let ua = headers
         .get("user-agent")
         .and_then(|v| v.to_str().ok())
         .map(String::from);
-    let xff = headers
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .map(String::from);
-    let mcp_proto = headers
-        .get("mcp-protocol-version")
-        .and_then(|v| v.to_str().ok())
-        .map(String::from);
-    let accept = headers
-        .get("accept")
-        .and_then(|v| v.to_str().ok())
-        .map(String::from);
 
     let mut meta = serde_json::Map::new();
-    if let Some(x) = xff {
-        meta.insert("x_forwarded_for".into(), Value::String(x));
+
+    // Kept verbatim under these exact keys: resolve_client_ip + the dashboard
+    // read `x_forwarded_for`, and detectors/exporters key on the other two.
+    if let Some(x) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+        meta.insert("x_forwarded_for".into(), Value::String(x.to_string()));
     }
-    if let Some(v) = mcp_proto {
-        meta.insert("mcp_protocol_version".into(), Value::String(v));
+    if let Some(v) = headers
+        .get("mcp-protocol-version")
+        .and_then(|v| v.to_str().ok())
+    {
+        meta.insert("mcp_protocol_version".into(), Value::String(v.to_string()));
     }
-    if let Some(a) = accept {
-        meta.insert("accept".into(), Value::String(a));
+    if let Some(a) = headers.get("accept").and_then(|v| v.to_str().ok()) {
+        meta.insert("accept".into(), Value::String(a.to_string()));
     }
+
+    // Curated allowlist. Key is the header name with '-' -> '_'; the value is
+    // truncated to keep the row bounded.
+    for name in CAPTURED_HEADERS {
+        if let Some(val) = headers.get(*name).and_then(|v| v.to_str().ok()) {
+            let truncated: String = val.chars().take(MAX_HEADER_VALUE_LEN).collect();
+            meta.insert(name.replace('-', "_"), Value::String(truncated));
+        }
+    }
+
     let client_meta = if meta.is_empty() {
         None
     } else {
@@ -172,6 +206,37 @@ fn remote_addr_from(headers: &HeaderMap, peer: SocketAddr) -> String {
         .and_then(|s| s.split(',').next().map(|p| p.trim().to_string()))
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| peer.to_string())
+}
+
+/// Fallback for any route the honeypot doesn't model as MCP. Scanners hammer
+/// paths like `/.env`, `/.git/config`, `/admin`, `/wp-login.php`; logging each
+/// as a `probe` event captures the broad recon surface and runs the same
+/// detectors (so a `/.env` probe still trips secret_exfil). The request body
+/// is intentionally not extracted — most scans are GETs, and not buffering it
+/// avoids a memory-exhaustion vector on this unthrottled route.
+async fn probe_handler(
+    method: http::Method,
+    uri: http::Uri,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<AppState>,
+) -> Response {
+    let (user_agent, client_meta) = header_meta(&headers);
+    let ctx = RequestContext {
+        session_id: generate_session_id(),
+        transport: "http",
+        remote_addr: Some(remote_addr_from(&headers, remote)),
+        user_agent,
+        client_meta,
+        persona: None,
+    };
+    let path = uri.path().to_string();
+    let query = uri.query().map(String::from);
+    state
+        .handler
+        .log_probe(ctx, method.as_str(), &path, query)
+        .await;
+    (StatusCode::NOT_FOUND, "not found").into_response()
 }
 
 #[async_trait]
@@ -280,6 +345,9 @@ impl Transport for HttpTransport {
             .route("/version", get(version_handler))
             .route("/", get(banner_handler))
             .route("/healthz", get(|| async { "ok" }))
+            // Everything else is a non-MCP probe: log it (and run detectors)
+            // before returning 404.
+            .fallback(probe_handler)
             .layer(cors)
             .with_state(state);
 
@@ -787,6 +855,48 @@ mod tests {
             "text/html,application/xhtml+xml;q=0.9".parse().unwrap(),
         );
         assert!(client_accepts_html(&h));
+    }
+
+    #[test]
+    fn header_meta_captures_curated_headers_and_keeps_legacy_keys() {
+        let mut h = HeaderMap::new();
+        h.insert("user-agent", "scanner/1.0".parse().unwrap());
+        h.insert("accept", "application/json".parse().unwrap());
+        h.insert("authorization", "Bearer attacker-token".parse().unwrap());
+        h.insert("cf-ipcountry", "CN".parse().unwrap());
+        h.insert("origin", "https://evil.test".parse().unwrap());
+        h.insert("x-forwarded-for", "203.0.113.7, 10.0.0.1".parse().unwrap());
+
+        let (ua, meta) = header_meta(&h);
+        assert_eq!(ua.as_deref(), Some("scanner/1.0"));
+        let m = meta.unwrap();
+        // Legacy keys preserved (resolve_client_ip + dashboard depend on them).
+        assert_eq!(m["accept"], "application/json");
+        assert_eq!(m["x_forwarded_for"], "203.0.113.7, 10.0.0.1");
+        // Curated headers captured, hyphens normalised to underscores.
+        assert_eq!(m["authorization"], "Bearer attacker-token");
+        assert_eq!(m["cf_ipcountry"], "CN");
+        assert_eq!(m["origin"], "https://evil.test");
+    }
+
+    #[test]
+    fn header_meta_truncates_oversized_header_values() {
+        let mut h = HeaderMap::new();
+        h.insert("authorization", "A".repeat(2000).parse().unwrap());
+        let (_ua, meta) = header_meta(&h);
+        let m = meta.unwrap();
+        assert_eq!(
+            m["authorization"].as_str().unwrap().chars().count(),
+            MAX_HEADER_VALUE_LEN
+        );
+    }
+
+    #[test]
+    fn header_meta_empty_when_no_known_headers() {
+        let h = HeaderMap::new();
+        let (ua, meta) = header_meta(&h);
+        assert!(ua.is_none());
+        assert!(meta.is_none());
     }
 
     struct CapturingHandler {

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -899,6 +899,37 @@ mod tests {
         assert!(meta.is_none());
     }
 
+    #[tokio::test]
+    async fn unmatched_route_hits_probe_fallback_and_returns_404() {
+        let handler = Arc::new(CapturingHandler {
+            last_ctx: tokio::sync::Mutex::new(None),
+        });
+        let state = AppState {
+            handler,
+            stats: None,
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+        };
+        let app = Router::new()
+            .route("/mcp", post(mcp_post_handler))
+            .fallback(probe_handler)
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        // A classic credential-file scan to an unmodeled path.
+        let resp = raw_get(&addr, "/.env", &[("User-Agent", "scanner/1.0")]).await;
+        assert_eq!(resp.status, 404);
+    }
+
     struct CapturingHandler {
         last_ctx: tokio::sync::Mutex<Option<RequestContext>>,
     }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -52,6 +52,20 @@ pub trait Handler: Send + Sync + 'static {
         req: JsonRpcRequest,
         ctx: RequestContext,
     ) -> Option<JsonRpcResponse>;
+
+    /// Log a non-MCP probe — a request to a path the honeypot doesn't model
+    /// as MCP (`/.env`, `/.git/config`, `/admin`, `/wp-login.php`, …). Lets a
+    /// transport feed the broad recon surface into the same events +
+    /// detections pipeline. Default is a no-op so handlers that don't care
+    /// aren't forced to implement it.
+    async fn log_probe(
+        &self,
+        _ctx: RequestContext,
+        _http_method: &str,
+        _path: &str,
+        _query: Option<String>,
+    ) {
+    }
 }
 
 /// A transport drives the event loop: pull requests, dispatch to handler, write responses.


### PR DESCRIPTION
Widens per-request attacker telemetry and starts recording the scan surface beyond MCP.

- `header_meta` captures a curated allowlist of high-signal headers into `client_meta` (authorization, x-api-key, origin, referer, accept-language/-encoding, x-real-ip, cf-connecting-ip, cf-ipcountry, true-client-ip, via, sec-*), each truncated, alongside the existing keys.
- Non-MCP requests (`/.env`, `/.git/config`, `/admin`, ...) hit a fallback handler that logs them as `probe` events and runs the detector registry — so a `/.env` scan trips `secret_exfil`. The request body is not buffered, keeping the unthrottled route memory-safe.
- Dispatcher gains `log_probe` (via the `Handler` trait) and a shared `persist_and_detect` helper reused by the JSON-RPC and probe paths.

101 lib + integration suites green; fmt + clippy clean.