### PR TITLE
chore(deploy): version the box auto-deploy CD scripts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,69 @@
+# Box auto-deploy (continuous deployment)
+
+The live honeypot box pulls, rebuilds, and restarts itself whenever `main`
+advances **and** every CI check-run on that commit is green. This directory is
+the canonical, versioned source of the box-side machinery so it can be restored
+if the box is ever rebuilt.
+
+## How it works
+
+A systemd timer polls every 3 minutes and runs `auto-deploy.sh`, which:
+
+1. `git fetch` and compares `HEAD` to `origin/main`. If unchanged, exits.
+2. If `main` advanced, queries the public GitHub REST API
+   (`/commits/<sha>/check-runs`) for that commit:
+   - any failed/cancelled/timed-out check → **skip** (do not deploy),
+   - any check still running → **wait** (re-check next cycle),
+   - all green → **deploy**.
+3. On deploy: `git reset --hard origin/main`, `docker compose build honeymcp`,
+   `docker compose up -d --force-recreate honeymcp`, then a `/healthz` check.
+
+`flock` prevents overlapping runs; the `./data` bind mount means the SQLite
+event store survives every recreate. The build runs on the box, which needs
+swap — see "Prerequisites".
+
+## Prerequisites
+
+- The repo cloned at `/home/ubuntu/honeymcp`, on `main`, tracking `origin/main`.
+- Docker Engine + Compose v2, with the `ubuntu` user in the `docker` group.
+- Swap (the build needs more than the box's RAM). Example, persisted:
+  ```bash
+  sudo fallocate -l 6G /swapfile && sudo chmod 600 /swapfile
+  sudo mkswap /swapfile && sudo swapon /swapfile
+  echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+  ```
+- `canaries.yaml` present in the repo root (gitignored) for real canary tokens.
+
+## Install
+
+```bash
+# 1. Canonical script -> installed copy the service runs.
+cp deploy/auto-deploy.sh /home/ubuntu/honeymcp-autodeploy.sh
+chmod +x /home/ubuntu/honeymcp-autodeploy.sh
+
+# 2. systemd units.
+sudo cp deploy/honeymcp-deploy.service deploy/honeymcp-deploy.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now honeymcp-deploy.timer
+```
+
+## Operate
+
+```bash
+# Watch deploy cycles live
+journalctl -u honeymcp-deploy.service -f
+
+# Next scheduled run
+systemctl list-timers honeymcp-deploy.timer
+
+# Pause / resume auto-deploy
+sudo systemctl disable --now honeymcp-deploy.timer
+sudo systemctl enable  --now honeymcp-deploy.timer
+
+# Force a check now
+sudo systemctl start honeymcp-deploy.service
+```
+
+After changing `auto-deploy.sh` in the repo, re-copy it to
+`/home/ubuntu/honeymcp-autodeploy.sh` (the service runs the installed copy, not
+the in-repo file, so a mid-deploy `git reset` can't rewrite the running script).

--- a/deploy/auto-deploy.sh
+++ b/deploy/auto-deploy.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# honeymcp box auto-deploy. Polled by honeymcp-deploy.timer.
+#
+# Deploys origin/main ONLY when it has advanced AND every CI check-run on that
+# commit is green (no failures, none pending). The CI gate uses the public
+# GitHub REST API (no token needed for a public repo). The build happens on the
+# box; the ./data volume is preserved across the recreate.
+#
+# Install: see deploy/README.md. The box runs an installed copy of this script
+# at /home/ubuntu/honeymcp-autodeploy.sh — this file is the canonical source.
+set -uo pipefail
+REPO=/home/ubuntu/honeymcp
+SLUG=kosiorkosa47/honeymcp
+BRANCH=main
+exec 9>/tmp/honeymcp-deploy.lock
+flock -n 9 || { echo "$(date -Is) deploy already running, skip"; exit 0; }
+
+cd "$REPO" || exit 1
+git fetch --quiet origin "$BRANCH" || { echo "$(date -Is) git fetch failed"; exit 0; }
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse "origin/$BRANCH")
+[ "$LOCAL" = "$REMOTE" ] && exit 0
+
+echo "$(date -Is) main advanced ${LOCAL:0:7} -> ${REMOTE:0:7}; checking CI"
+verdict=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/$SLUG/commits/$REMOTE/check-runs?per_page=100" 2>/dev/null \
+  | python3 -c '
+import sys, json
+try: d = json.load(sys.stdin)
+except Exception: print("WAIT no-json"); raise SystemExit
+runs = d.get("check_runs", [])
+if not runs: print("WAIT no-checks"); raise SystemExit
+bad = [r["name"] for r in runs if r.get("conclusion") in ("failure","cancelled","timed_out","action_required","startup_failure")]
+pending = [r["name"] for r in runs if r.get("status") != "completed"]
+if bad: print("SKIP failed: "+", ".join(bad)); raise SystemExit
+if pending: print("WAIT pending: "+", ".join(pending)); raise SystemExit
+print("DEPLOY")
+')
+echo "$(date -Is) verdict: $verdict"
+[ "${verdict%% *}" = "DEPLOY" ] || exit 0
+
+echo "$(date -Is) deploying ${REMOTE:0:7}"
+git reset --hard "origin/$BRANCH" >/dev/null 2>&1
+if docker compose build honeymcp >/tmp/honeymcp-deploy-build.log 2>&1 \
+   && docker compose up -d --force-recreate honeymcp >/dev/null 2>&1; then
+  sleep 6
+  if curl -fsS --max-time 5 http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+    echo "$(date -Is) DEPLOYED ${REMOTE:0:7} OK (healthz green)"
+  else
+    echo "$(date -Is) WARNING ${REMOTE:0:7} deployed but healthz failed"
+  fi
+else
+  echo "$(date -Is) ERROR build/up failed for ${REMOTE:0:7} (see /tmp/honeymcp-deploy-build.log)"
+fi

--- a/deploy/honeymcp-deploy.service
+++ b/deploy/honeymcp-deploy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=honeymcp auto-deploy (pull+build+restart when main is green)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ubuntu
+WorkingDirectory=/home/ubuntu/honeymcp
+ExecStart=/home/ubuntu/honeymcp-autodeploy.sh
+TimeoutStartSec=1200

--- a/deploy/honeymcp-deploy.timer
+++ b/deploy/honeymcp-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Poll for honeymcp updates every 3 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=3min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds `deploy/` — the canonical, versioned source for the box-side continuous deployment (systemd timer + `auto-deploy.sh` + README). The box pulls, rebuilds and restarts honeymcp whenever `main` advances and every CI check-run on that commit is green; the SQLite event store survives each recreate. No runtime/app changes.