### PR TITLE
feat(detect): cloud-attack detectors (ssrf/imds, traversal, aws-intent, scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ I built honeymcp because there's no public record of what attackers actually sen
 
 It's one Rust binary. About 15 MB, SQLite on disk, fits in 256 MiB of RAM. You run it, point DNS, and it answers MCP handshakes the way a real server would. Personas are YAML. I ship four out of the box (`postgres-admin`, `github-admin`, `vercel-admin`, `stripe-finance`) covering the surfaces attackers actually go after: source code, deployments, environment variables, financial data. Anyone scanning the internet for MCP endpoints gets a full conversation with fake tools and canned responses that hold up under multi-turn interrogation.
 
-What lands in SQLite: timestamp, method, IP, User-Agent, client name and version, the `Mcp-Session-Id` they used, the `MCP-Protocol-Version` they claimed, and a SHA-256 of the raw params so reruns correlate. Seven detectors tag events at write time, so you can grep for "prompt-injection traffic that also did tool-enumeration" without scanning the whole DB.
+What lands in SQLite: timestamp, method, IP, User-Agent, client name and version, the `Mcp-Session-Id` they used, the `MCP-Protocol-Version` they claimed, and a SHA-256 of the raw params so reruns correlate. Eleven detectors tag events at write time, so you can grep for "prompt-injection traffic that also did tool-enumeration" without scanning the whole DB.
 
 It's not a proxy. It won't protect your production MCP server. It's a trap you put on the internet to learn from. `GET /` returns a plain-text banner saying exactly that with a GDPR erasure contact. `GET /dashboard` is a server-rendered analyst surface (Attack Story Timeline grouped per session + per-session MCP Sequence Diagram SVG at `/dashboard/sequence/<id>.svg`); operator traffic is filtered out by default with a `?include_operator=true` toggle. No admin panel, no write path exposed to the network.
 
@@ -42,7 +42,7 @@ MCP is a young protocol with a rapidly growing attack surface: **tool poisoning*
 - Ships **four personas** out of the box: `postgres-admin`, `github-admin`, `vercel-admin`, `stripe-finance` - covering source code, deployments, environment variables, and financial data.
 - Ships as a **Docker image** for one-command deploy; release builds are cosign-keyless-signed with SPDX + CycloneDX SBOMs attached and **SLSA Level 3 build provenance** verifiable via `gh attestation verify` (recipe in [`docs/SLSA.md`](docs/SLSA.md)).
 - Serves an **operator banner** (research-honeypot disclosure + GDPR contact) at `GET /` and a server-rendered **analyst dashboard** at `/dashboard` (Attack Story Timeline + per-session MCP Sequence Diagram, all assets bundled in the binary, design in [`docs/dashboard-v2-design.md`](docs/dashboard-v2-design.md)).
-- Runs **seven threat detectors** (prompt injection, shell injection, CVE-2025-59536-class hook injection, secret exfil, unicode anomaly, recon, tool enumeration) on every request, tagging events at write time. Each detection carries its **MITRE ATT&CK / ATLAS technique IDs** in the `detections.mitre_techniques` column so SIEM consumers can pivot on technique without re-deriving the mapping. Full mapping in [`docs/MITRE-MAPPING.md`](docs/MITRE-MAPPING.md).
+- Runs **eleven threat detectors** (prompt injection, shell injection, CVE-2025-59536-class hook injection, secret exfil, unicode anomaly, recon, tool enumeration, IMDS-SSRF, path traversal, AWS tool-intent, scanner fingerprinting) on every request, tagging events at write time. Each detection carries its **MITRE ATT&CK / ATLAS technique IDs** in the `detections.mitre_techniques` column so SIEM consumers can pivot on technique without re-deriving the mapping. Full mapping in [`docs/MITRE-MAPPING.md`](docs/MITRE-MAPPING.md).
 - Logs every request/response to **SQLite** (primary, queryable) and optionally mirrors to **JSONL** (grep/jq-friendly), including timestamp, method, SHA-256 of params, raw params, client name/version, session id, transport, remote address, and User-Agent.
 - **Tags operator traffic** at write time (`is_operator` column). `/stats` excludes probes and validation curls by default so any number a third party reads is the external-only corpus; pass `?include_operator=true` to fold them back in.
 - **Exposes build provenance** at `GET /version` (crate version, 12-char git short sha with a `-dirty` suffix when relevant, RFC3339 build time). Every deploy is verifiable in one curl.
@@ -132,9 +132,10 @@ src/
   protocol/    JSON-RPC 2.0 + MCP payload types
   transport/   Transport trait, stdio + http (Streamable + legacy SSE)
   persona/     YAML persona loader + validator
-  detect/      Seven detectors (prompt_injection, shell_injection,
+  detect/      Eleven detectors (prompt_injection, shell_injection,
                cve_59536, secret_exfil, unicode_anomaly, recon,
-               tool_enumeration)
+               tool_enumeration, ssrf_imds, path_traversal,
+               aws_intent, scanner_fingerprint)
   logger/      SQLite + JSONL structured logging
   server.rs    Session / request dispatcher
   main.rs      CLI entry (clap)

--- a/docs/MITRE-MAPPING.md
+++ b/docs/MITRE-MAPPING.md
@@ -20,6 +20,11 @@ direct evidence link, not a "could-conceivably-fit" association.
 | `cve_2025_59536_config_injection` | `T1190`, `T1059` | Exploit Public-Facing Application — CVE-2025-59536 is a remote config injection in `mcp-remote` chaining to RCE |
 | `unicode_anomaly` | `T1027`, `T1036.005` | Obfuscated Files or Information / Match Legitimate Resource Name — bidi marks + tag-block + homoglyph subsets |
 | `tool_enumeration` | `T1518`, `T1083` | Software Discovery — calling many distinct tools per session maps installed capabilities |
+| `ssrf_imds` | `T1552.005`, `T1552` | Unsecured Credentials — Cloud Instance Metadata API; matches IMDS endpoints (`169.254.169.254`, `metadata.google.internal`, ECS / Alibaba) in tool arguments |
+| `path_traversal` | `T1083`, `T1006` | File and Directory Discovery / Direct Volume Access — `../`, `..\` and URL-encoded traversal sequences, independent of the final target |
+| `aws_intent` (credential access) | `T1552`, `T1555.006`, `T1098.001`, `T1078.004`, `T1548`, `T1530`, `T1552.001` | Secrets Manager / SSM read, IAM access-key creation, STS AssumeRole, S3 object pull, persona file read — classified per AWS tool name |
+| `aws_intent` (discovery) | `T1580`, `T1087.004` | Cloud Infrastructure Discovery / Cloud Account Discovery — `list_secrets`, `list_iam_users`, `describe_instances`, `get_caller_identity` |
+| `scanner_fingerprint` | `T1595`, `T1592` | Active Scanning / Gather Victim Host Information — labels Censys, Shodan, MCP-specific scanners and raw HTTP clients once per session |
 
 ## ATLAS techniques (LLM-specific)
 

--- a/src/detect/aws_intent.rs
+++ b/src/detect/aws_intent.rs
@@ -1,0 +1,128 @@
+//! AWS tool-intent classifier.
+//!
+//! Labels `tools/call` invocations by what they would do on a real cloud
+//! account — credential access (Secrets Manager / SSM reads, IAM key creation,
+//! STS AssumeRole, S3 object pulls) versus discovery (account / infrastructure
+//! enumeration). This turns "an attacker poked the AWS persona" into a typed
+//! signal with a cloud ATT&CK mapping, on top of the path/keyword detectors.
+
+use crate::detect::{Detection, DetectionCategory, DetectionContext, Detector, Severity};
+
+pub struct AwsIntentDetector;
+
+impl Detector for AwsIntentDetector {
+    fn name(&self) -> &'static str {
+        "aws_intent"
+    }
+
+    fn category(&self) -> DetectionCategory {
+        // Reported per-call; this is the detector's nominal bucket.
+        DetectionCategory::SecretExfil
+    }
+
+    fn analyze(&self, ctx: &DetectionContext) -> Option<Detection> {
+        if ctx.entry.method != "tools/call" {
+            return None;
+        }
+        let name = ctx.entry.params.as_ref()?.get("name")?.as_str()?;
+
+        let (severity, category, note, mitre): (
+            Severity,
+            DetectionCategory,
+            &'static str,
+            &'static [&'static str],
+        ) = match name {
+            "get_secret_value" | "get_ssm_parameter" => (
+                Severity::Critical,
+                DetectionCategory::SecretExfil,
+                "secrets-manager / SSM parameter read",
+                &["T1552", "T1555.006"],
+            ),
+            "create_access_key" => (
+                Severity::Critical,
+                DetectionCategory::SecretExfil,
+                "IAM long-lived access-key creation",
+                &["T1098.001", "T1078.004"],
+            ),
+            "assume_role" => (
+                Severity::High,
+                DetectionCategory::SecretExfil,
+                "STS AssumeRole credential request",
+                &["T1548", "T1078.004"],
+            ),
+            "s3_get_object" => (
+                Severity::High,
+                DetectionCategory::SecretExfil,
+                "S3 object download",
+                &["T1530"],
+            ),
+            "read_file" => (
+                Severity::High,
+                DetectionCategory::SecretExfil,
+                "host file read via cloud-ops persona",
+                &["T1552.001"],
+            ),
+            "list_secrets"
+            | "list_iam_users"
+            | "list_s3_buckets"
+            | "describe_instances"
+            | "get_caller_identity" => (
+                Severity::Medium,
+                DetectionCategory::Recon,
+                "cloud infrastructure / account discovery",
+                &["T1580", "T1087.004"],
+            ),
+            _ => return None,
+        };
+
+        Some(Detection {
+            detector: "aws_intent",
+            category,
+            severity,
+            evidence: name.to_string(),
+            notes: Some(note.to_string()),
+            mitre_techniques: mitre,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::testing::{ctx, make_entry};
+    use crate::detect::SessionStats;
+    use serde_json::json;
+
+    #[test]
+    fn flags_get_secret_value_as_critical_secret_exfil() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"get_secret_value","arguments":{"secret_id":"prod/iam/deploy-keys"}}),
+        );
+        let d = AwsIntentDetector.analyze(&ctx(&e, &s)).unwrap();
+        assert_eq!(d.severity, Severity::Critical);
+        assert_eq!(d.category, DetectionCategory::SecretExfil);
+        assert!(!d.mitre_techniques.is_empty());
+    }
+
+    #[test]
+    fn flags_discovery_tools_as_recon() {
+        let s = SessionStats::default();
+        let e = make_entry("tools/call", json!({"name":"list_secrets","arguments":{}}));
+        let d = AwsIntentDetector.analyze(&ctx(&e, &s)).unwrap();
+        assert_eq!(d.category, DetectionCategory::Recon);
+    }
+
+    #[test]
+    fn ignores_unknown_tools_and_non_calls() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"search_documentation","arguments":{}}),
+        );
+        assert!(AwsIntentDetector.analyze(&ctx(&e, &s)).is_none());
+        let e2 = make_entry("tools/list", json!({}));
+        assert!(AwsIntentDetector.analyze(&ctx(&e2, &s)).is_none());
+    }
+}

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -13,11 +13,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::logger::LogEntry;
 
+pub mod aws_intent;
 pub mod cve_59536;
+pub mod path_traversal;
 pub mod prompt_injection;
 pub mod recon;
+pub mod scanner_fingerprint;
 pub mod secret_exfil;
 pub mod shell_injection;
+pub mod ssrf_imds;
 pub mod tool_enumeration;
 pub mod unicode_anomaly;
 
@@ -112,6 +116,10 @@ impl Registry {
                 Box::new(shell_injection::ShellInjectionDetector),
                 Box::new(recon::ReconDetector),
                 Box::new(secret_exfil::SecretExfilDetector),
+                Box::new(ssrf_imds::SsrfImdsDetector),
+                Box::new(path_traversal::PathTraversalDetector),
+                Box::new(aws_intent::AwsIntentDetector),
+                Box::new(scanner_fingerprint::ScannerFingerprintDetector),
                 Box::new(cve_59536::Cve59536Detector),
                 Box::new(unicode_anomaly::UnicodeAnomalyDetector),
                 Box::new(tool_enumeration::ToolEnumerationDetector),

--- a/src/detect/path_traversal.rs
+++ b/src/detect/path_traversal.rs
@@ -1,0 +1,98 @@
+//! Path traversal sequences.
+//!
+//! Flags tool arguments containing `../` / `..\` (or their URL-encoded forms).
+//! Complements `secret_exfil`, which matches *known* sensitive paths by name:
+//! this catches the traversal *technique* regardless of the final target, so a
+//! climb toward an arbitrary file is caught even when the destination isn't on
+//! the secret-exfil list.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use crate::detect::{Detection, DetectionCategory, DetectionContext, Detector, Severity};
+
+pub struct PathTraversalDetector;
+
+fn pattern() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(
+            r"(?ix)
+            (
+                \.\./                       # ../
+              | \.\.\\                      # ..\
+              | %2e%2e%2f                   # encoded ../
+              | %2e%2e/
+              | \.\.%2f
+              | %2e%2e%5c                   # encoded ..\
+              | \.\.%5c
+            )
+            ",
+        )
+        .expect("path traversal regex")
+    })
+}
+
+impl Detector for PathTraversalDetector {
+    fn name(&self) -> &'static str {
+        "path_traversal"
+    }
+
+    fn category(&self) -> DetectionCategory {
+        DetectionCategory::SecretExfil
+    }
+
+    fn analyze(&self, ctx: &DetectionContext) -> Option<Detection> {
+        let params = ctx.entry.params.as_ref()?;
+        let body = params.to_string();
+        let m = pattern().find(&body)?;
+        Some(Detection {
+            detector: "path_traversal",
+            category: DetectionCategory::SecretExfil,
+            severity: Severity::High,
+            evidence: m.as_str().to_string(),
+            notes: Some(format!("traversal sequence in {} args", ctx.entry.method)),
+            // T1083: File and Directory Discovery.
+            // T1006: Direct Volume Access (reading files outside the intended root).
+            mitre_techniques: &["T1083", "T1006"],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::testing::{ctx, make_entry};
+    use crate::detect::SessionStats;
+    use serde_json::json;
+
+    #[test]
+    fn triggers_on_dotdot_slash() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"read_file","arguments":{"path":"../../../../etc/shadow"}}),
+        );
+        assert!(PathTraversalDetector.analyze(&ctx(&e, &s)).is_some());
+    }
+
+    #[test]
+    fn triggers_on_url_encoded_traversal() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"get","arguments":{"path":"%2e%2e%2f%2e%2e%2fboot.ini"}}),
+        );
+        assert!(PathTraversalDetector.analyze(&ctx(&e, &s)).is_some());
+    }
+
+    #[test]
+    fn negative_plain_path() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"read_file","arguments":{"path":"reports/2026/q2.csv"}}),
+        );
+        assert!(PathTraversalDetector.analyze(&ctx(&e, &s)).is_none());
+    }
+}

--- a/src/detect/scanner_fingerprint.rs
+++ b/src/detect/scanner_fingerprint.rs
@@ -1,0 +1,129 @@
+//! Scanner / automated-client fingerprinting.
+//!
+//! Classifies the User-Agent of the first MCP message in a session so the
+//! benign-but-noisy crawler traffic (Censys, Shodan, MCP-specific scanners,
+//! raw HTTP libraries) becomes a labelled dimension instead of being dropped.
+//! Fires at most once per session and never on probe events (those already get
+//! their own path/keyword detections).
+
+use crate::detect::{Detection, DetectionCategory, DetectionContext, Detector, Severity};
+
+pub struct ScannerFingerprintDetector;
+
+fn classify(ua_lower: &str) -> Option<&'static str> {
+    if ua_lower.contains("censys") {
+        Some("censys internet-wide scanner")
+    } else if ua_lower.contains("shodan") {
+        Some("shodan scanner")
+    } else if ua_lower.contains("mcp scan") || ua_lower.contains("mcp-scan") {
+        Some("mcp-specific scanner")
+    } else if ua_lower.contains("zgrab")
+        || ua_lower.contains("masscan")
+        || ua_lower.contains("nmap")
+    {
+        Some("network scanner")
+    } else if ua_lower.contains("nuclei")
+        || ua_lower.contains("nikto")
+        || ua_lower.contains("sqlmap")
+    {
+        Some("vulnerability scanner")
+    } else if ua_lower.contains("aiohttp")
+        || ua_lower.contains("python-requests")
+        || ua_lower.starts_with("python/")
+        || ua_lower.contains("python-httpx")
+        || ua_lower.contains("go-http-client")
+        || ua_lower.contains("okhttp")
+        || ua_lower.contains("curl/")
+        || ua_lower.contains("wget/")
+    {
+        Some("automated http client")
+    } else {
+        None
+    }
+}
+
+impl Detector for ScannerFingerprintDetector {
+    fn name(&self) -> &'static str {
+        "scanner_fingerprint"
+    }
+
+    fn category(&self) -> DetectionCategory {
+        DetectionCategory::Recon
+    }
+
+    fn analyze(&self, ctx: &DetectionContext) -> Option<Detection> {
+        // Once per session, and not on the probe surface.
+        if ctx.entry.method == "probe" || ctx.stats.calls_in_session > 1 {
+            return None;
+        }
+        let ua = ctx.entry.user_agent.as_deref()?;
+        let label = classify(&ua.to_ascii_lowercase())?;
+        Some(Detection {
+            detector: "scanner_fingerprint",
+            category: DetectionCategory::Recon,
+            severity: Severity::Low,
+            evidence: ua.chars().take(120).collect(),
+            notes: Some(label.to_string()),
+            // T1595: Active Scanning. T1592: Gather Victim Host Information.
+            mitre_techniques: &["T1595", "T1592"],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::testing::{ctx, make_entry};
+    use crate::detect::SessionStats;
+    use serde_json::json;
+
+    fn entry_with_ua(
+        method: &str,
+        ua: Option<&str>,
+        calls: u32,
+    ) -> (crate::logger::LogEntry, SessionStats) {
+        let mut e = make_entry(method, json!({}));
+        e.user_agent = ua.map(String::from);
+        let s = SessionStats {
+            calls_in_session: calls,
+            ..Default::default()
+        };
+        (e, s)
+    }
+
+    #[test]
+    fn labels_censys_on_first_event() {
+        let (e, s) = entry_with_ua(
+            "initialize",
+            Some("Mozilla/5.0 (compatible; CensysInspect/1.1; +https://about.censys.io/)"),
+            1,
+        );
+        let d = ScannerFingerprintDetector.analyze(&ctx(&e, &s)).unwrap();
+        assert_eq!(d.detector, "scanner_fingerprint");
+        assert!(
+            !d.mitre_techniques.is_empty(),
+            "must carry MITRE techniques"
+        );
+        assert!(d.notes.unwrap().contains("censys"));
+    }
+
+    #[test]
+    fn labels_python_aiohttp() {
+        let (e, s) = entry_with_ua("initialize", Some("Python/3.13 aiohttp/3.13.2"), 1);
+        assert!(ScannerFingerprintDetector.analyze(&ctx(&e, &s)).is_some());
+    }
+
+    #[test]
+    fn does_not_fire_after_first_event_or_on_probe() {
+        let (e, s) = entry_with_ua("tools/list", Some("Python/3.13 aiohttp/3.13.2"), 3);
+        assert!(ScannerFingerprintDetector.analyze(&ctx(&e, &s)).is_none());
+        let (e2, s2) = entry_with_ua("probe", Some("CensysInspect/1.1"), 1);
+        assert!(ScannerFingerprintDetector.analyze(&ctx(&e2, &s2)).is_none());
+    }
+
+    #[test]
+    fn ignores_real_client_user_agent() {
+        let (e, s) = entry_with_ua("initialize", Some("claude-desktop/1.2.0"), 1);
+        assert!(ScannerFingerprintDetector.analyze(&ctx(&e, &s)).is_none());
+    }
+}

--- a/src/detect/ssrf_imds.rs
+++ b/src/detect/ssrf_imds.rs
@@ -1,0 +1,97 @@
+//! Cloud instance metadata (IMDS) SSRF targets.
+//!
+//! Fires when a tool argument references a cloud metadata endpoint. Hitting the
+//! link-local metadata service is the canonical way to turn a server-side
+//! request into stolen instance credentials, so any reference to one from an
+//! MCP tool call is high-confidence credential theft — there is no legitimate
+//! reason for an agent to ask a random MCP server to fetch `169.254.169.254`.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use crate::detect::{Detection, DetectionCategory, DetectionContext, Detector, Severity};
+
+pub struct SsrfImdsDetector;
+
+fn pattern() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(
+            r"(?ix)
+            (
+                169\.254\.169\.254          # AWS / Azure / GCP IMDS
+              | metadata\.google\.internal  # GCP metadata DNS name
+              | 169\.254\.170\.2            # ECS task metadata
+              | 100\.100\.100\.200          # Alibaba Cloud metadata
+              | metadata\.azure\.com
+              | fd00:ec2::254               # AWS IMDSv6
+            )
+            ",
+        )
+        .expect("imds ssrf regex")
+    })
+}
+
+impl Detector for SsrfImdsDetector {
+    fn name(&self) -> &'static str {
+        "ssrf_imds"
+    }
+
+    fn category(&self) -> DetectionCategory {
+        DetectionCategory::SecretExfil
+    }
+
+    fn analyze(&self, ctx: &DetectionContext) -> Option<Detection> {
+        let params = ctx.entry.params.as_ref()?;
+        let body = params.to_string();
+        let m = pattern().find(&body)?;
+        Some(Detection {
+            detector: "ssrf_imds",
+            category: DetectionCategory::SecretExfil,
+            severity: Severity::Critical,
+            evidence: m.as_str().to_string(),
+            notes: Some("cloud instance metadata endpoint (credential theft via SSRF)".into()),
+            // T1552.005: Unsecured Credentials — Cloud Instance Metadata API.
+            // T1552: Unsecured Credentials (parent).
+            mitre_techniques: &["T1552.005", "T1552"],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::testing::{ctx, make_entry};
+    use crate::detect::SessionStats;
+    use serde_json::json;
+
+    #[test]
+    fn triggers_on_aws_imds_ip() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"fetch_url","arguments":{"url":"http://169.254.169.254/latest/meta-data/iam/security-credentials/"}}),
+        );
+        assert!(SsrfImdsDetector.analyze(&ctx(&e, &s)).is_some());
+    }
+
+    #[test]
+    fn triggers_on_gcp_metadata_name() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"read_url","arguments":{"url":"http://metadata.google.internal/computeMetadata/v1/"}}),
+        );
+        assert!(SsrfImdsDetector.analyze(&ctx(&e, &s)).is_some());
+    }
+
+    #[test]
+    fn negative_ordinary_url() {
+        let s = SessionStats::default();
+        let e = make_entry(
+            "tools/call",
+            json!({"name":"fetch","arguments":{"url":"https://api.acme-corp.com/v1/health"}}),
+        );
+        assert!(SsrfImdsDetector.analyze(&ctx(&e, &s)).is_none());
+    }
+}

--- a/tests/mitre_mapping.rs
+++ b/tests/mitre_mapping.rs
@@ -192,6 +192,36 @@ fn tool_enumeration_emits_t1518() {
 }
 
 #[test]
+fn ssrf_imds_emits_t1552_005() {
+    assert_detector_emits_techniques(
+        "tools/call",
+        json!({"name":"fetch_url","arguments":{"url":"http://169.254.169.254/latest/meta-data/iam/security-credentials/"}}),
+        SessionStats::default(),
+        "ssrf_imds",
+    );
+}
+
+#[test]
+fn path_traversal_emits_t1083() {
+    assert_detector_emits_techniques(
+        "tools/call",
+        json!({"name":"read_file","arguments":{"path":"../../../../etc/shadow"}}),
+        SessionStats::default(),
+        "path_traversal",
+    );
+}
+
+#[test]
+fn aws_intent_emits_cloud_techniques() {
+    assert_detector_emits_techniques(
+        "tools/call",
+        json!({"name":"get_secret_value","arguments":{"secret_id":"prod/iam/deploy-keys"}}),
+        SessionStats::default(),
+        "aws_intent",
+    );
+}
+
+#[test]
 fn technique_id_validator_rejects_typos() {
     // Sanity-check the validator itself so a future loosening is loud.
     assert!(looks_like_technique_id("T1059"));


### PR DESCRIPTION
Adds four detectors (registry 7 -> 11):

- **ssrf_imds** — cloud instance metadata endpoints (`169.254.169.254`, `metadata.google.internal`, ECS/Alibaba) in tool args → critical credential theft via SSRF (T1552.005).
- **path_traversal** — `../` / `..\` and URL-encoded traversal sequences regardless of target, complementing keyword-based `secret_exfil` (T1083, T1006).
- **aws_intent** — classifies AWS-persona tool calls as credential access vs discovery with per-tool cloud ATT&CK mappings.
- **scanner_fingerprint** — labels Censys/Shodan/MCP-scanner/raw-HTTP UAs once per session, turning crawler noise into a dimension (T1595, T1592).

MITRE contract test extended; README + docs/MITRE-MAPPING.md updated. 115 lib + integration suites green; fmt + clippy clean.