### PR TITLE
feat(dashboard): split counts by attack surface; bind backend to loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Dashboard splits counts by attack surface.** Events and detector hits are
+  now reported as MCP surface vs probe surface, so commodity web scanning that
+  lands on the non-MCP probe paths (`/.env`, `/.git`, ...) no longer inflates
+  the numbers that should describe MCP-targeted threat. The "detector hits"
+  headline reflects the MCP surface.
 - **Multi-persona routing.** One process now serves several personas, selected
   by URL path (`/<persona>/mcp`), over a single database and dashboard. The
   bare `/mcp` serves the default; an unknown key falls back to the default
@@ -34,6 +39,12 @@
 
 - The `events` table gained a `persona` column (added in place, backwards
   compatible) so the dashboard and exports can attribute and filter by persona.
+
+### Security
+
+- The honeypot container binds to `127.0.0.1:8080`; all external traffic
+  reaches it through Caddy, so the backend is no longer directly addressable on
+  the internet on port 8080.
 
 ### CI / infrastructure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,11 @@ services:
     tmpfs:
       - /tmp:size=32m,mode=1777
     ports:
-      - "8080:8080"
+      # Bind to loopback only: the honeypot is reached through Caddy
+      # (reverse_proxy 127.0.0.1:8080), never directly from the internet. This
+      # keeps a single logged entry point and stops a scanner from hitting the
+      # backend on :8080, bypassing the proxy.
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./data:/var/lib/honeymcp
       - ./personas:/opt/honeymcp/personas:ro

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -82,6 +82,10 @@ pub struct DashboardQuery {
 struct StatsForTemplate {
     total_events: i64,
     total_detections: i64,
+    mcp_events: i64,
+    probe_events: i64,
+    mcp_detections: i64,
+    probe_detections: i64,
     unique_remote_addrs_24h: i64,
     operator_traffic_included: bool,
     server: ServerForTemplate,
@@ -178,6 +182,10 @@ pub async fn index_handler(
     let stats_for_template = StatsForTemplate {
         total_events: stats_snap.total_events,
         total_detections: stats_snap.total_detections,
+        mcp_events: stats_snap.mcp_events,
+        probe_events: stats_snap.probe_events,
+        mcp_detections: stats_snap.mcp_detections,
+        probe_detections: stats_snap.probe_detections,
         unique_remote_addrs_24h: stats_snap.unique_remote_addrs_24h,
         operator_traffic_included: stats_snap.operator_traffic_included,
         server: ServerForTemplate {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -6,6 +6,7 @@
   <div class="hm-stat">
     <div class="hm-stat-label">external events</div>
     <div class="hm-stat-value">{{ stats.total_events }}</div>
+    <div class="hm-stat-meta">MCP {{ stats.mcp_events }} &middot; probe {{ stats.probe_events }}</div>
     <div class="hm-stat-meta">
       {% if stats.operator_traffic_included %}
         <span class="hm-badge hm-badge--operator">includes operator traffic</span>
@@ -21,8 +22,8 @@
   </div>
   <div class="hm-stat">
     <div class="hm-stat-label">detector hits</div>
-    <div class="hm-stat-value">{{ stats.total_detections }}</div>
-    <div class="hm-stat-meta">across all sessions</div>
+    <div class="hm-stat-value">{{ stats.mcp_detections }}</div>
+    <div class="hm-stat-meta">MCP surface &middot; probe {{ stats.probe_detections }}</div>
   </div>
   <div class="hm-stat">
     <div class="hm-stat-label">persona</div>

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -384,6 +384,58 @@ impl Logger {
         Ok(n)
     }
 
+    /// Event counts split by attack surface: `(mcp, probe)`. The probe surface
+    /// is everything logged from a non-MCP path (`method = 'probe'`, the
+    /// `/.env` / `/.git` / `/admin` scan traffic); the MCP surface is the real
+    /// protocol interactions. Keeping them apart stops commodity web scanning
+    /// from inflating the numbers that should describe MCP-targeted threat.
+    pub async fn count_events_by_surface(&self, include_operator: bool) -> Result<(i64, i64)> {
+        let db = self.inner.db.lock().await;
+        let op = if include_operator {
+            ""
+        } else {
+            " AND is_operator = 0"
+        };
+        let mcp: i64 = db.query_row(
+            &format!("SELECT COUNT(*) FROM events WHERE method != 'probe'{op}"),
+            [],
+            |r| r.get(0),
+        )?;
+        let probe: i64 = db.query_row(
+            &format!("SELECT COUNT(*) FROM events WHERE method = 'probe'{op}"),
+            [],
+            |r| r.get(0),
+        )?;
+        Ok((mcp, probe))
+    }
+
+    /// Detection counts split by the parent event's surface: `(mcp, probe)`.
+    pub async fn count_detections_by_surface(&self, include_operator: bool) -> Result<(i64, i64)> {
+        let db = self.inner.db.lock().await;
+        let op = if include_operator {
+            ""
+        } else {
+            " AND e.is_operator = 0"
+        };
+        let mcp: i64 = db.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM detections d JOIN events e ON e.id = d.event_id
+                 WHERE e.method != 'probe'{op}"
+            ),
+            [],
+            |r| r.get(0),
+        )?;
+        let probe: i64 = db.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM detections d JOIN events e ON e.id = d.event_id
+                 WHERE e.method = 'probe'{op}"
+            ),
+            [],
+            |r| r.get(0),
+        )?;
+        Ok((mcp, probe))
+    }
+
     /// Top N tool names called via `tools/call`, derived by extracting
     /// `params.name` from the stored JSON.
     pub async fn top_tools(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -27,6 +27,14 @@ pub struct StatsSnapshot {
     pub server: ServerIdentity,
     pub total_events: i64,
     pub total_detections: i64,
+    /// Event and detection counts split by attack surface. The MCP surface is
+    /// real protocol traffic; the probe surface is non-MCP scan paths
+    /// (`/.env`, `/.git`, ...). Splitting them keeps commodity web scanning
+    /// from inflating the MCP-threat numbers.
+    pub mcp_events: i64,
+    pub probe_events: i64,
+    pub mcp_detections: i64,
+    pub probe_detections: i64,
     pub events_by_method: Vec<(String, i64)>,
     pub detections_by_category: Vec<(String, i64)>,
     pub unique_remote_addrs_24h: i64,
@@ -73,6 +81,15 @@ impl StatsProvider for LoggerStatsProvider {
         let now_ms = crate::logger::now_ms();
         let day_ago_ms = now_ms - 24 * 60 * 60 * 1000;
 
+        let (mcp_events, probe_events) = self
+            .logger
+            .count_events_by_surface(include_operator)
+            .await?;
+        let (mcp_detections, probe_detections) = self
+            .logger
+            .count_detections_by_surface(include_operator)
+            .await?;
+
         Ok(StatsSnapshot {
             uptime_seconds: self.started.elapsed().as_secs(),
             server: ServerIdentity {
@@ -82,6 +99,10 @@ impl StatsProvider for LoggerStatsProvider {
             },
             total_events: self.logger.count_events(include_operator).await?,
             total_detections: self.logger.count_detections(include_operator).await?,
+            mcp_events,
+            probe_events,
+            mcp_detections,
+            probe_detections,
             events_by_method: self.logger.events_by_method(include_operator).await?,
             detections_by_category: self.logger.detections_by_category(include_operator).await?,
             unique_remote_addrs_24h: self


### PR DESCRIPTION
Splits the dashboard's event and detector counts into **MCP surface** vs **probe surface** (`method = 'probe'`), so commodity web scanning on `/.env` / `/.git` paths no longer inflates the MCP-threat numbers. The "detector hits" headline now reflects the MCP surface. Also hardens exposure: the container binds to `127.0.0.1:8080` so the backend is reached only through Caddy, not directly from the internet.