### PR TITLE
ci: least-privilege permissions for the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: CI only reads the repo. Jobs that need more declare it
+# locally.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
Declare `permissions: contents: read` at the workflow level so the default GITHUB_TOKEN is read-only (jobs that need more declare it locally). Closes the one workflow that lacked an explicit permissions block.