### PR TITLE
Host hardening and attack intelligence dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- **Dashboard attack-intelligence overview.** `/dashboard` now derives a
+  last-24h analyst view from SQLite: attack classes, attacker goal summaries,
+  top campaigns grouped by source/user-agent/class, MCP risk score, source
+  country pulse map, detector co-occurrence heatmap, live SSE feed, and a
+  one-click markdown report at `/dashboard/report.md`.
+- **Persona-vs-observed-intent SVG.** `/dashboard/sankey.svg` renders a
+  dependency-free server-side flow from persona surface to observed attack
+  class, so operators can see whether traffic is actually exercising MCP tools
+  or just probing generic web paths.
 - **Dashboard splits counts by attack surface.** Events and detector hits are
   now reported as MCP surface vs probe surface, so commodity web scanning that
   lands on the non-MCP probe paths (`/.env`, `/.git`, ...) no longer inflates
@@ -22,8 +31,8 @@
   arguments). New `--canaries` flag plus `./canaries.yaml` auto-discovery.
 - **Wider request telemetry.** A curated allowlist of high-signal headers
   (`authorization`, `x-api-key`, `origin`, `referer`, `cf-connecting-ip`,
-  `cf-ipcountry`, `x-real-ip`, `true-client-ip`, `via`, `sec-*`) is captured
-  into `client_meta`, each value truncated.
+  `cf-ipcountry`, `geoip-country`, `x-real-ip`, `true-client-ip`, `via`,
+  `sec-*`) is captured into `client_meta`, each value truncated.
 - **Non-MCP probe logging.** Requests to unmodelled paths (`/.env`,
   `/.git/config`, `/admin`, and the like) are logged as `probe` events and run
   through the detector registry, so a credential-file scan trips `secret_exfil`
@@ -54,6 +63,10 @@
 - **Box auto-deploy.** A systemd timer pulls, rebuilds and restarts the live
   honeypot whenever `main` advances and every CI check-run on that commit is
   green. Scripts versioned under [`deploy/`](deploy/).
+- **Docker build provenance from deploy SHA.** `docker compose build` now
+  passes the checked CI-green `origin/main` commit into `build.rs`, so
+  `/version` reports a traceable git sha even when the Docker build context
+  does not include `.git`.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM rust:1.89-slim-bookworm AS builder
 WORKDIR /build
+ARG HONEYMCP_GIT_SHA=unknown
+ARG HONEYMCP_BUILD_UNIX_TS
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY src ./src
@@ -9,10 +11,12 @@ COPY src ./src
 # manifest fails to load. Cheap to copy (3 files, <500 lines) and it keeps the
 # release binary scope tight via --bin honeymcp.
 COPY benches ./benches
-# build.rs reads .git/HEAD if present to stamp HONEYMCP_GIT_SHA. The build
-# context here usually has no .git tree, so the script falls back to "unknown"
-# at compile time. Release builds populate it via CI env (see release.yml).
-RUN cargo build --bin honeymcp --release --locked
+# build.rs reads HONEYMCP_GIT_SHA first, then falls back to .git/HEAD if the
+# build context includes a git tree. Box deploys pass the origin/main commit as
+# a build arg so /version always exposes the exact deployed revision.
+RUN HONEYMCP_GIT_SHA="$HONEYMCP_GIT_SHA" \
+    HONEYMCP_BUILD_UNIX_TS="$HONEYMCP_BUILD_UNIX_TS" \
+    cargo build --bin honeymcp --release --locked
 
 FROM debian:bookworm-slim
 # curl is for the HEALTHCHECK script; ca-certificates + libssl3 are deps for

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Status:** Building toward v1.0 on a 28-day sprint. Currently speaks Streamable HTTP (MCP spec 2025-06-18) and legacy HTTP+SSE side by side.
 
-**Live:** [operator banner](http://54.169.235.208/) + [dashboard](http://54.169.235.208/dashboard).
+**Live:** [operator banner](http://54.169.235.208/) + [operator-auth dashboard](http://54.169.235.208/dashboard).
 
 ## What this is
 
@@ -23,7 +23,7 @@ It's one Rust binary. About 15 MB, SQLite on disk, fits in 256 MiB of RAM. You r
 
 What lands in SQLite: timestamp, method, IP, User-Agent, client name and version, the `Mcp-Session-Id` they used, the `MCP-Protocol-Version` they claimed, and a SHA-256 of the raw params so reruns correlate. Eleven detectors tag events at write time, so you can grep for "prompt-injection traffic that also did tool-enumeration" without scanning the whole DB.
 
-It's not a proxy. It won't protect your production MCP server. It's a trap you put on the internet to learn from. `GET /` returns a plain-text banner saying exactly that with a GDPR erasure contact. `GET /dashboard` is a server-rendered analyst surface (Attack Story Timeline grouped per session + per-session MCP Sequence Diagram SVG at `/dashboard/sequence/<id>.svg`); operator traffic is filtered out by default with a `?include_operator=true` toggle. No admin panel, no write path exposed to the network.
+It's not a proxy. It won't protect your production MCP server. It's a trap you put on the internet to learn from. `GET /` returns a plain-text banner saying exactly that with a GDPR erasure contact. `GET /dashboard` is a server-rendered analyst surface (attack-intelligence overview, source-country map, campaign grouping, live feed, Attack Story Timeline, per-session MCP Sequence Diagram SVG at `/dashboard/sequence/<id>.svg`, and markdown report at `/dashboard/report.md`); operator traffic is filtered out by default with a `?include_operator=true` toggle. No admin panel, no write path exposed to the network.
 
 `honeymcp-probes` is the second binary in this crate. It fires the same 13 payloads the detectors are tuned for, so you can audit your own MCP server without standing up a honeypot. Same codebase, same taxonomy.
 
@@ -37,11 +37,11 @@ MCP is a young protocol with a rapidly growing attack surface: **tool poisoning*
 - Speaks **Streamable HTTP** (MCP spec 2025-06-18): `POST /mcp` with `Accept`-based negotiation (JSON or single-message SSE), `GET /mcp` for server-to-client SSE, `DELETE /mcp` for explicit session teardown, session identified by `Mcp-Session-Id` header.
 - Speaks **legacy HTTP+SSE** (`POST /message`, `GET /sse`) for older clients that have not moved to the 2025-06-18 transport yet.
 - Handles `initialize`, `tools/list`, `tools/call`, and the common `notifications/*` frames.
-- Records a curated allowlist of high-signal request headers (`MCP-Protocol-Version`, `X-Forwarded-For`, `Authorization`, `Origin`, `Referer`, `CF-Connecting-IP`, `CF-IPCountry`, `X-Real-IP`, `Accept`, `User-Agent`, and more) into `client_meta`, and logs non-MCP scan paths (`/.env`, `/.git/config`, ...) as `probe` events that still run through the detectors.
+- Records a curated allowlist of high-signal request headers (`MCP-Protocol-Version`, `X-Forwarded-For`, `Authorization`, `Origin`, `Referer`, `CF-Connecting-IP`, `CF-IPCountry`, `GeoIP-Country`, `X-Real-IP`, `Accept`, `User-Agent`, and more) into `client_meta`, and logs non-MCP scan paths (`/.env`, `/.git/config`, ...) as `probe` events that still run through the detectors.
 - Loads **personas** from YAML - server name, version, instructions, and a list of fake tools with canned responses, with optional `{{canary.*}}` and `{{arg.*}}` response templating.
 - Serves **several personas from one process**, routed by URL path (`/<persona>/mcp`); the default image runs `aws-admin` (cloud ops with live canary credentials), `github-admin`, `vercel-admin`, and `stripe-finance` together, with `postgres-admin` and `filesystem-admin` also bundled.
 - Ships as a **Docker image** for one-command deploy; release builds are cosign-keyless-signed with SPDX + CycloneDX SBOMs attached and **SLSA Level 3 build provenance** verifiable via `gh attestation verify` (recipe in [`docs/SLSA.md`](docs/SLSA.md)).
-- Serves an **operator banner** (research-honeypot disclosure + GDPR contact) at `GET /` and a server-rendered **analyst dashboard** at `/dashboard` (Attack Story Timeline + per-session MCP Sequence Diagram, all assets bundled in the binary, design in [`docs/dashboard-v2-design.md`](docs/dashboard-v2-design.md)).
+- Serves an **operator banner** (research-honeypot disclosure + GDPR contact) at `GET /` and a server-rendered **analyst dashboard** at `/dashboard` (attack classes, campaigns, Geo-IP pulse map, detector co-occurrence heatmap, MCP risk score, live SSE feed, markdown report, Attack Story Timeline, and per-session MCP Sequence Diagram; all assets bundled in the binary, design in [`docs/dashboard-v2-design.md`](docs/dashboard-v2-design.md)).
 - Runs **eleven threat detectors** (prompt injection, shell injection, CVE-2025-59536-class hook injection, secret exfil, unicode anomaly, recon, tool enumeration, IMDS-SSRF, path traversal, AWS tool-intent, scanner fingerprinting) on every request, tagging events at write time. Each detection carries its **MITRE ATT&CK / ATLAS technique IDs** in the `detections.mitre_techniques` column so SIEM consumers can pivot on technique without re-deriving the mapping. Full mapping in [`docs/MITRE-MAPPING.md`](docs/MITRE-MAPPING.md).
 - Logs every request/response to **SQLite** (primary, queryable) and optionally mirrors to **JSONL** (grep/jq-friendly), including timestamp, method, SHA-256 of params, raw params, client name/version, session id, transport, remote address, and User-Agent.
 - **Tags operator traffic** at write time (`is_operator` column). `/stats` excludes probes and validation curls by default so any number a third party reads is the external-only corpus; pass `?include_operator=true` to fold them back in.
@@ -280,7 +280,7 @@ for this line and tracked separately if they ever come back.
 | Track | Focus | Status |
 |------|-------|--------|
 | Foundation | stdio + Streamable HTTP + legacy HTTP+SSE, 7 detectors, CI (fmt + clippy + test matrix + audit + deny + coverage), signed release workflow + cosign + SBOMs, threat model + GDPR LIA | ✅ `v0.6.0` shipped 2026-04-27 |
-| Operator surface | Operator banner, `/version` build provenance, `is_operator` traffic filter, server-rendered analyst dashboard (Attack Story Timeline + per-session MCP Sequence Diagram) | ✅ shipped on `v0.6` line |
+| Operator surface | Operator banner, `/version` build provenance, `is_operator` traffic filter, server-rendered analyst dashboard (attack-intel overview, campaigns, Geo-IP pulse map, heatmap, live feed, report, Attack Story Timeline + per-session MCP Sequence Diagram) | ✅ shipped on `v0.6`/`v0.7` line |
 | Persona library | `postgres-admin`, `github-admin`, `vercel-admin`, `stripe-finance` shipped; `figma-dev` / `cloudflare-edge` / `linear-pm` open as `good first issue` | 4 of 7 shipped |
 | Storage backends | SQLite is the operator default. Postgres + pgvector lives behind `--features postgres` with the migration set ready; the recorder side is scaffold-only and lights up when corpus growth justifies it | scaffold |
 | Observability | `--features otel` wires the OTLP exporter (`tracing-opentelemetry`); `HONEYMCP_LOG_FORMAT=json` for ndjson stderr; `Dispatcher::handle_request` is `#[instrument]`-ed | code ready, production wiring pending (see [`docs/scope-decisions.md`](docs/scope-decisions.md)) |

--- a/build.rs
+++ b/build.rs
@@ -2,29 +2,46 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn main() {
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short=12", "HEAD"])
-        .output()
+    let supplied_sha = std::env::var("HONEYMCP_GIT_SHA")
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+        .map(|s| short_sha(&s))
+        .filter(|s| !s.is_empty() && s != "unknown");
 
-    let dirty = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false);
+    let (sha, dirty) = match supplied_sha {
+        Some(sha) => (sha, false),
+        None => {
+            let sha = Command::new("git")
+                .args(["rev-parse", "--short=12", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            let dirty = Command::new("git")
+                .args(["status", "--porcelain"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| !o.stdout.is_empty())
+                .unwrap_or(false);
+
+            (sha, dirty)
+        }
+    };
 
     let sha = if dirty { format!("{sha}-dirty") } else { sha };
 
-    let unix_ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    let unix_ts = std::env::var("HONEYMCP_BUILD_UNIX_TS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        });
 
     println!("cargo:rustc-env=HONEYMCP_GIT_SHA={sha}");
     println!("cargo:rustc-env=HONEYMCP_BUILD_UNIX_TS={unix_ts}");
@@ -32,4 +49,15 @@ fn main() {
     // Re-run if HEAD changes; the index check is cheap and avoids stale stamps.
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-env-changed=HONEYMCP_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=HONEYMCP_BUILD_UNIX_TS");
+}
+
+fn short_sha(raw: &str) -> String {
+    let s = raw.trim();
+    if s.len() > 12 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        s.chars().take(12).collect()
+    } else {
+        s.to_string()
+    }
 }

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,22 @@
+{
+	servers {
+		trusted_proxies static private_ranges
+	}
+}
+
+:80 {
+	@operator path /dashboard /dashboard/* /stats /healthz /version
+	basic_auth @operator {
+		# Keep the credential hash out of git. The imported file should contain
+		# one Caddy basic_auth line, for example:
+		#   admin $2a$14$...
+		import /etc/honeymcp/dashboard-basic-auth
+	}
+
+	reverse_proxy 127.0.0.1:8080
+
+	log {
+		output file /var/log/caddy/access.log
+		format json
+	}
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,6 +26,8 @@ swap — see "Prerequisites".
 
 - The repo cloned at `/home/ubuntu/honeymcp`, on `main`, tracking `origin/main`.
 - Docker Engine + Compose v2, with the `ubuntu` user in the `docker` group.
+- Caddy installed on the host, terminating public HTTP/HTTPS and proxying to
+  `127.0.0.1:8080`.
 - Swap (the build needs more than the box's RAM). Example, persisted:
   ```bash
   sudo fallocate -l 6G /swapfile && sudo chmod 600 /swapfile
@@ -37,14 +39,38 @@ swap — see "Prerequisites".
 ## Install
 
 ```bash
-# 1. Canonical script -> installed copy the service runs.
-cp deploy/auto-deploy.sh /home/ubuntu/honeymcp-autodeploy.sh
+# 1. Stable wrapper -> versioned script in the checked-out repo.
+cat > /home/ubuntu/honeymcp-autodeploy.sh <<'EOF'
+#!/bin/sh
+set -eu
+cd /home/ubuntu/honeymcp
+exec ./deploy/auto-deploy.sh
+EOF
 chmod +x /home/ubuntu/honeymcp-autodeploy.sh
 
 # 2. systemd units.
 sudo cp deploy/honeymcp-deploy.service deploy/honeymcp-deploy.timer /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now honeymcp-deploy.timer
+```
+
+Bootstrap the one local secret the repo must not carry:
+
+```bash
+sudo install -d -m 0755 /etc/honeymcp
+caddy hash-password
+# paste the hash, not the plaintext password:
+echo 'admin <hash>' | sudo tee /etc/honeymcp/dashboard-basic-auth >/dev/null
+sudo chmod 0640 /etc/honeymcp/dashboard-basic-auth
+sudo chown root:caddy /etc/honeymcp/dashboard-basic-auth
+```
+
+Install the host-side hardening units as part of a rebuild. The auto-deploy
+script also runs this on every successful `main` deploy so the live box
+converges back to the versioned host configuration.
+
+```bash
+./deploy/apply-host-hardening.sh
 ```
 
 ## Operate
@@ -64,6 +90,6 @@ sudo systemctl enable  --now honeymcp-deploy.timer
 sudo systemctl start honeymcp-deploy.service
 ```
 
-After changing `auto-deploy.sh` in the repo, re-copy it to
-`/home/ubuntu/honeymcp-autodeploy.sh` (the service runs the installed copy, not
-the in-repo file, so a mid-deploy `git reset` can't rewrite the running script).
+`/home/ubuntu/honeymcp-autodeploy.sh` is intentionally only a stable wrapper.
+The deploy logic lives in `deploy/auto-deploy.sh`, so changes to deploy
+behaviour go through GitHub and are picked up from the checked-out repo.

--- a/deploy/apply-host-hardening.sh
+++ b/deploy/apply-host-hardening.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+REPO=${REPO:-/home/ubuntu/honeymcp}
+CADDYFILE_SRC=${CADDYFILE_SRC:-$REPO/deploy/Caddyfile}
+DASHBOARD_AUTH_FILE=${DASHBOARD_AUTH_FILE:-/etc/honeymcp/dashboard-basic-auth}
+
+if [ "$(id -u)" -eq 0 ]; then
+	SUDO=
+else
+	SUDO=sudo
+fi
+
+require_file() {
+	if [ ! -s "$1" ]; then
+		echo "missing required file: $1" >&2
+		exit 1
+	fi
+}
+
+install_caddyfile() {
+	require_file "$CADDYFILE_SRC"
+	require_file "$DASHBOARD_AUTH_FILE"
+
+	tmp=$($SUDO mktemp /tmp/honeymcp-caddy.XXXXXX)
+	$SUDO install -m 0644 "$CADDYFILE_SRC" "$tmp"
+	$SUDO caddy fmt --overwrite "$tmp" >/dev/null
+	$SUDO caddy validate --adapter caddyfile --config "$tmp" >/dev/null
+	$SUDO install -m 0644 "$tmp" /etc/caddy/Caddyfile
+	$SUDO rm -f "$tmp"
+	$SUDO systemctl reload caddy
+}
+
+install_imds_block() {
+	$SUDO install -m 0755 "$REPO/deploy/honeymcp-imds-block.sh" \
+		/usr/local/sbin/honeymcp-imds-block.sh
+	$SUDO install -m 0644 "$REPO/deploy/honeymcp-imds-block.service" \
+		/etc/systemd/system/honeymcp-imds-block.service
+	$SUDO systemctl daemon-reload
+	$SUDO systemctl enable --now honeymcp-imds-block.service >/dev/null
+}
+
+lock_down_ufw() {
+	if command -v ufw >/dev/null 2>&1; then
+		printf 'y\n' | $SUDO ufw delete allow 8080/tcp >/dev/null 2>&1 || true
+	fi
+}
+
+install_caddyfile
+install_imds_block
+lock_down_ufw

--- a/deploy/auto-deploy.sh
+++ b/deploy/auto-deploy.sh
@@ -63,7 +63,8 @@ echo "$(date -Is) verdict: $verdict"
 echo "$(date -Is) deploying ${REMOTE:0:7}"
 git reset --hard "origin/$BRANCH" >/dev/null 2>&1
 apply_host_hardening "$REMOTE" || exit 1
-if docker compose build honeymcp >/tmp/honeymcp-deploy-build.log 2>&1 \
+if HONEYMCP_GIT_SHA="$REMOTE" HONEYMCP_BUILD_UNIX_TS="$(date +%s)" \
+   docker compose build honeymcp >/tmp/honeymcp-deploy-build.log 2>&1 \
    && docker compose up -d --force-recreate honeymcp >/dev/null 2>&1; then
   sleep 6
   if curl -fsS --max-time 5 http://127.0.0.1:8080/healthz >/dev/null 2>&1; then

--- a/deploy/auto-deploy.sh
+++ b/deploy/auto-deploy.sh
@@ -12,14 +12,35 @@ set -uo pipefail
 REPO=/home/ubuntu/honeymcp
 SLUG=kosiorkosa47/honeymcp
 BRANCH=main
+HARDENING_STAMP=/home/ubuntu/.honeymcp-host-hardening.sha
 exec 9>/tmp/honeymcp-deploy.lock
 flock -n 9 || { echo "$(date -Is) deploy already running, skip"; exit 0; }
 
 cd "$REPO" || exit 1
+
+apply_host_hardening() {
+  sha="$1"
+  if [ ! -x ./deploy/apply-host-hardening.sh ]; then
+    echo "$(date -Is) WARNING host hardening script missing; skip"
+    return 0
+  fi
+  if ./deploy/apply-host-hardening.sh >/tmp/honeymcp-host-hardening.log 2>&1; then
+    printf '%s\n' "$sha" >"$HARDENING_STAMP"
+    echo "$(date -Is) host hardening applied for ${sha:0:7}"
+  else
+    echo "$(date -Is) ERROR host hardening failed for ${sha:0:7} (see /tmp/honeymcp-host-hardening.log)"
+    return 1
+  fi
+}
+
 git fetch --quiet origin "$BRANCH" || { echo "$(date -Is) git fetch failed"; exit 0; }
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse "origin/$BRANCH")
-[ "$LOCAL" = "$REMOTE" ] && exit 0
+if [ "$LOCAL" = "$REMOTE" ]; then
+  APPLIED=$(cat "$HARDENING_STAMP" 2>/dev/null || true)
+  [ "$APPLIED" = "$LOCAL" ] || apply_host_hardening "$LOCAL"
+  exit 0
+fi
 
 echo "$(date -Is) main advanced ${LOCAL:0:7} -> ${REMOTE:0:7}; checking CI"
 verdict=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
@@ -41,6 +62,7 @@ echo "$(date -Is) verdict: $verdict"
 
 echo "$(date -Is) deploying ${REMOTE:0:7}"
 git reset --hard "origin/$BRANCH" >/dev/null 2>&1
+apply_host_hardening "$REMOTE" || exit 1
 if docker compose build honeymcp >/tmp/honeymcp-deploy-build.log 2>&1 \
    && docker compose up -d --force-recreate honeymcp >/dev/null 2>&1; then
   sleep 6

--- a/deploy/honeymcp-imds-block.service
+++ b/deploy/honeymcp-imds-block.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Block Docker containers from reaching cloud IMDS
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/honeymcp-imds-block.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/honeymcp-imds-block.sh
+++ b/deploy/honeymcp-imds-block.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+# DOCKER-USER only sees Docker-forwarded packets, so this blocks container
+# access to cloud metadata without affecting host-level IMDS access.
+/sbin/iptables -C DOCKER-USER -d 169.254.169.254/32 -j DROP 2>/dev/null \
+  || /sbin/iptables -I DOCKER-USER 1 -d 169.254.169.254/32 -j DROP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,11 @@ services:
         max-file: "3"
 
   honeymcp:
-    build: .
+    build:
+      context: .
+      args:
+        HONEYMCP_GIT_SHA: ${HONEYMCP_GIT_SHA:-unknown}
+        HONEYMCP_BUILD_UNIX_TS: ${HONEYMCP_BUILD_UNIX_TS:-}
     image: honeymcp:0.7.0
 
     container_name: honeymcp

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,17 +49,32 @@ services:
       - --jsonl=/var/lib/honeymcp/hive.jsonl
 ```
 
-Then `docker compose up -d --force-recreate`.
+Then `docker compose up -d --force-recreate`. Keep the compose port publish
+bound to `127.0.0.1:8080`; Caddy is the only internet-facing entry point.
 
 ## Putting it on the internet
 
-The container binds `0.0.0.0:8080` on the host. To expose it on port 443 with automatic TLS, put [Caddy](https://caddyserver.com/) in front of it.
+The container publishes `127.0.0.1:8080` on the host. To expose the honeypot
+on port 80/443, put [Caddy](https://caddyserver.com/) in front of it and keep
+operator endpoints behind Basic Auth.
 
 ### `/etc/caddy/Caddyfile`
 
 ```
+{
+    servers {
+        trusted_proxies static private_ranges
+    }
+}
+
 honeymcp.example.com {
+    @operator path /dashboard /dashboard/* /stats /healthz /version
+    basic_auth @operator {
+        import /etc/honeymcp/dashboard-basic-auth
+    }
+
     reverse_proxy 127.0.0.1:8080
+
     log {
         output file /var/log/caddy/honeymcp.log
         format json
@@ -79,17 +94,28 @@ sudo apt update && sudo apt install -y caddy
 sudo systemctl reload caddy
 ```
 
-Caddy provisions a Let's Encrypt certificate for `honeymcp.example.com` automatically on first request.
+Caddy provisions a Let's Encrypt certificate for `honeymcp.example.com`
+automatically on first request. Keep the Basic Auth hash outside git:
+
+```bash
+sudo install -d -m 0755 /etc/honeymcp
+caddy hash-password
+# paste the hash, not the plaintext password:
+echo 'admin <hash>' | sudo tee /etc/honeymcp/dashboard-basic-auth >/dev/null
+sudo chmod 0640 /etc/honeymcp/dashboard-basic-auth
+sudo chown root:caddy /etc/honeymcp/dashboard-basic-auth
+```
 
 ### Firewall / `ufw`
 
-Assuming ufw is your firewall, allow HTTP + HTTPS (for Caddy) and deny direct access to 8080 from the internet:
+Assuming ufw is your firewall, allow SSH plus HTTP/HTTPS for Caddy. Do not
+allow direct access to 8080; the backend is loopback-only and should stay
+reachable only through Caddy.
 
 ```bash
 sudo ufw allow 22/tcp     # SSH
 sudo ufw allow 80/tcp     # Caddy ACME challenge
 sudo ufw allow 443/tcp    # HTTPS
-sudo ufw deny 8080/tcp    # Direct access to the honeypot backend (Caddy stays on localhost)
 sudo ufw enable
 ```
 
@@ -99,6 +125,23 @@ sudo ufw enable
 sudo iptables -A INPUT -p tcp --dport 80  -j ACCEPT
 sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 sudo iptables -A INPUT -p tcp --dport 8080 ! -i lo -j DROP
+```
+
+### Block container access to IMDS
+
+The honeypot container should not be able to reach cloud instance metadata
+services. Install the versioned unit from `deploy/`:
+
+```bash
+sudo cp deploy/honeymcp-imds-block.sh /usr/local/sbin/honeymcp-imds-block.sh
+sudo chmod 0755 /usr/local/sbin/honeymcp-imds-block.sh
+sudo cp deploy/honeymcp-imds-block.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now honeymcp-imds-block.service
+
+docker exec honeymcp curl -sS --connect-timeout 2 --max-time 3 \
+  http://169.254.169.254/latest/meta-data/
+# expected: connection timeout / no response
 ```
 
 ## Making the honeypot discoverable

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -21,19 +21,24 @@ expected to find guidance under.
 ## Service overview
 
 `honeymcp` is a single Rust binary that pretends to be an MCP server,
-records every request to SQLite (and optionally JSONL), runs seven
+records every request to SQLite (and optionally JSONL), runs eleven
 threat detectors against the params, and exposes a server-rendered
 analyst dashboard at `/dashboard`.
 
-The deployed surface is intentionally minimal:
+The application surface is intentionally minimal. In the production Caddy
+deployment, `/dashboard`, `/dashboard/*`, `/stats`, `/healthz`, and
+`/version` are operator-only behind Basic Auth; public traffic reaches only
+the banner and MCP honeypot paths. The container port is bound to loopback.
 
 | Path | Purpose |
 | --- | --- |
 | `GET /` | Operator banner — research-honeypot disclosure + GDPR contact |
-| `GET /healthz` | Liveness + readiness probe |
-| `GET /version` | Build provenance (crate version + git sha + build time) |
-| `GET /stats` | JSON event counters; defaults to `is_operator=0` |
-| `GET /dashboard` | Server-rendered Attack Story Timeline |
+| `GET /healthz` | Operator liveness + readiness probe |
+| `GET /version` | Operator build provenance (crate version + git sha + build time) |
+| `GET /stats` | Operator JSON event counters; defaults to `is_operator=0` |
+| `GET /dashboard` | Operator dashboard: attack intel, campaigns, geo, heatmap, feed, timeline |
+| `GET /dashboard/feed` | Operator SSE stream of new events |
+| `GET /dashboard/report.md` | Operator markdown attack report |
 | `POST /mcp` | Streamable HTTP MCP transport (spec 2025-06-18) |
 | `GET /mcp`, `DELETE /mcp` | SSE stream + session teardown |
 | `POST /message`, `GET /sse` | Legacy HTTP+SSE transport |
@@ -60,7 +65,7 @@ quarantine the pulled image.
 ```bash
 docker run -d --name honeymcp \
     --restart unless-stopped \
-    -p 8080:8080 \
+    -p 127.0.0.1:8080:8080 \
     -v /var/lib/honeymcp:/var/lib/honeymcp \
     ghcr.io/kosiorkosa47/honeymcp:latest \
     --transport http \
@@ -99,7 +104,7 @@ If any of those fail, see [Common alerts](#common-alerts-and-responses).
 | Probe | Healthy | Unhealthy |
 | --- | --- | --- |
 | `GET /healthz` | `200 OK` body `ok` | Anything else |
-| `GET /version` | JSON with non-`unknown` `git_sha` | `git_sha = "unknown"` means the build isn't traceable |
+| `GET /version` | JSON with non-`unknown` `git_sha` | `git_sha = "unknown"` means the Docker build did not receive `HONEYMCP_GIT_SHA` |
 | `du -sh /var/lib/honeymcp/hive.db` | < 5 GB on a small VPS | Investigate trim path; the logger drops the oldest 10% at 1M events but a stuck trim is possible |
 | `journalctl -u honeymcp` (or `docker logs`) | No `ERROR` lines for ~5 min | Persistent `ERROR` lines = read [Triage queries](#triage-queries) |
 
@@ -170,7 +175,9 @@ Tail logs for the failing template; almost always one of:
 
 The deployed binary wasn't built with `HONEYMCP_GIT_SHA` set. This
 means the image isn't traceable to a commit and is **not safe to
-deploy** to a public IP. Rebuild from a tagged release.
+deploy** to a public IP. Rebuild through the versioned deploy path;
+`deploy/auto-deploy.sh` passes the checked `origin/main` sha into
+`docker compose build`.
 
 ## Triage queries
 

--- a/docs/dashboard-v2-design.md
+++ b/docs/dashboard-v2-design.md
@@ -92,26 +92,24 @@ detector strikes. The visual difference between the two is the point.
 This is the component nobody else has shipped. It only makes sense for an
 MCP honeypot because it encodes the protocol's session shape.
 
-### 3. Persona-vs-Reality Sankey (PR 2)
+### 3. Persona-vs-Reality Sankey (implemented)
 
-Two-column sankey. Left: tools the active persona advertises. Right: tools
-attackers actually invoked via `tools/call`. Width of each link encodes
-the call count.
+Two-column SVG. Left: persona or probe surface. Right: observed attack class.
+Width of each link encodes the event count.
 
 The visual claim of the project from the first-week blog post -- "tool
 catalogue is advisory, not load-bearing" -- becomes a single-screen proof
-the moment week-six corpus has any volume. Until that volume arrives this
-panel renders an honest empty-state explaining the threshold.
+the moment corpus has any volume. Until that volume arrives this panel renders
+an honest empty-state.
 
-### 4. Detector Co-occurrence Heatmap (PR 2)
+### 4. Detector Co-occurrence Heatmap (implemented)
 
-7x7 heatmap of detector x detector. Cell colour encodes the conditional
-probability that detector Y fires given that detector X fired in the same
-event. `recon` x `tool_enumeration` should be hot; `secret_exfil` x
-`unicode_anomaly` should be cool. Surface non-obvious correlations the
-scalar bar charts cannot reveal.
+Top-N heatmap of detector x detector. Cell colour encodes how often detector
+Y appears with detector X in the same session. `recon` x `tool_enumeration`
+should be hot; `secret_exfil` x `unicode_anomaly` should be cool. Surface
+non-obvious correlations the scalar bar charts cannot reveal.
 
-### 5. Live Feed with honest badges (PR 3)
+### 5. Live Feed with honest badges (implemented)
 
 Streaming list of the latest events. Two visual states per row: green dot
 external, grey dot operator. Default toggle is `external only`. The toggle
@@ -121,12 +119,11 @@ shareable; bookmarks survive operator changes.
 This is the most explicit place where the methodology is shown to the
 reader rather than buried in CHANGELOG.
 
-### 6. Geo-IP Pulse Map (PR 3)
+### 6. Geo-IP Pulse Map (implemented)
 
-Small-multiples world map with one dot per resolved IP, animated forward
-through the corpus window. No fake "1.4M attacks/sec" theatre. A counter
-strip below the map shows the honest external-only number with a 24h
-delta.
+Small country-level pulse map with dots when `CF-IPCountry`, `GeoIP-Country`
+or another local enrichment source is present. No fake "1.4M attacks/sec"
+theatre; unknown country stays explicitly unknown.
 
 ### 7. Build Provenance Footer (PR 4)
 
@@ -157,10 +154,11 @@ context.
 | ---                        | ---    | ---                                |
 | `/dashboard`               | GET    | Server-rendered shell + initial state |
 | `/dashboard/feed`          | GET    | SSE stream of new events           |
+| `/dashboard/report.md`     | GET    | Markdown last-24h attack report    |
 | `/dashboard/session/{id}`  | GET    | HTML partial for one session card (htmx swap target) |
 | `/dashboard/sequence/{id}` | GET    | SVG per-session sequence diagram   |
 | `/dashboard/sankey.svg`    | GET    | Persona-vs-reality sankey image    |
-| `/dashboard/heatmap.svg`   | GET    | Detector co-occurrence heatmap     |
+| `/dashboard/heatmap.svg`   | GET    | Detector co-occurrence heatmap (planned SVG export; table is in `/dashboard`) |
 
 Every endpoint is content-negotiated. `Accept: application/json` returns
 machine-readable data so the same routes work for embedded reports and

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -7,8 +7,8 @@ contributors, not as a legal document.
 
 - **Framework:** STRIDE (Spoofing, Tampering, Repudiation, Information
   disclosure, Denial of service, Elevation of privilege).
-- **Last reviewed:** 2026-04-24 for honeymcp v0.5.0 + `main` (Streamable HTTP
-  transport).
+- **Last reviewed:** 2026-06-24 for honeymcp v0.7.0 + `main` (multi-persona
+  Streamable HTTP transport, probe logging, dashboard auth deployment).
 
 ## 0. System context
 
@@ -23,14 +23,17 @@ A honeymcp deployment is one process that speaks the Model Context Protocol
 The process loads a **persona** (tool catalogue + canned responses) from a
 YAML file and serves plausible MCP responses back. Each request and response
 is passed through a set of **detectors** (prompt injection, shell injection,
-recon, etc.) and persisted to SQLite and optionally a JSONL mirror.
+recon, cloud metadata probes, scanner fingerprints, etc.) and persisted to
+SQLite and optionally a JSONL mirror.
 
-There are **three trust zones**:
+There are **four trust zones**:
 
 1. **Attacker** - unauthenticated internet client, potentially scripted.
-2. **Operator** - the human running the honeypot. Has the persona files,
+2. **Reverse proxy / host boundary** - Caddy, firewall and Docker port binding
+   that keep operator endpoints private and the backend on loopback.
+3. **Operator** - the human running the honeypot. Has the persona files,
    the database, and the host.
-3. **Consumer of threat intel** - later readers of the captured corpus.
+4. **Consumer of threat intel** - later readers of the captured corpus.
 
 honeymcp is designed so that attackers stay in zone 1 even when they
 successfully exercise the attack payloads we want to capture.
@@ -83,10 +86,10 @@ and leaking the log back to the attacker is one of the worst failure modes.
 |---|---|---|
 | Attacker drops a live credential into a tool call; honeymcp echoes it back in the JSON-RPC result | Response payloads are static from persona YAML; no echoing of request content | Detectors may surface matched content to the dashboard - **do not expose the dashboard to the public internet** |
 | Attacker triggers verbose error that leaks server stack / versions | axum default error handling kept, no debug bodies in production; `RUSTFLAGS: -D warnings` catches unintended debug prints | Error bodies for malformed JSON still include parser message; acceptable because it's JSON-RPC `-32700` boilerplate, but a hardened build could suppress |
-| Detection of honeymcp via banner / dashboard fingerprint | **Accepted leak.** A honeypot that hides its dashboard is a honeypot that silently mis-attributes real production traffic. We serve a documented research banner (`docs/legal/operator-banner.md`) at `GET /` | N/A |
+| Detection of honeymcp via banner fingerprint | **Accepted leak.** We serve a documented research banner (`docs/legal/operator-banner.md`) at `GET /` so traffic is not misrepresented as a production service | N/A |
 | Secrets in captured payloads leak to logs / stdout | `redact_secrets` replaces known tokens (GitHub PAT, AWS access keys, PEM keys, JWTs, Slack tokens) before writing response text | Request params stored raw for forensics; redaction only applies to responses and to probe outputs |
 | Attacker reads the DB via SQL injection in some helper endpoint | No query parameters are interpolated into SQL; we use prepared statements everywhere | N/A; keep this invariant if adding endpoints |
-| `/stats` / `/dashboard` expose attacker IPs to the world | Dashboard is unauthenticated by design (low-value live view, aggregates only). Deployments that want to keep this private should put it behind a VPN or reverse-proxy auth | No built-in basic-auth toggle |
+| `/stats` / `/dashboard` expose attacker IPs to the world | The production deployment protects `/dashboard`, `/dashboard/*`, `/stats`, `/healthz`, and `/version` with Caddy Basic Auth and keeps the container backend bound to `127.0.0.1:8080` | The binary itself still does not implement auth; direct-exposed deployments must use a trusted reverse proxy |
 
 ### 2.5 Denial of service
 
@@ -156,6 +159,7 @@ Re-run the STRIDE pass when any of the following changes:
 - A new detector category is introduced that might regex-match on response
   bodies rather than just request params.
 - The storage backend changes (SQLite -> Postgres migration is planned).
-- Any auth / session-state mechanism lands (currently stateless-per-session).
+- Any new auth / session-state mechanism lands in the binary rather than the
+  reverse proxy.
 - A new category of user-supplied input appears (e.g. operator-uploaded
   personas via web UI instead of file).

--- a/src/dashboard/analytics.rs
+++ b/src/dashboard/analytics.rs
@@ -1,0 +1,1466 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::net::{IpAddr, Ipv4Addr};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::logger::RawEventRow;
+
+const MAX_DASHBOARD_ROWS: usize = 5_000;
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct DashboardAnalytics {
+    pub window_label: String,
+    pub event_count: usize,
+    pub detection_count: usize,
+    pub attack_classes: Vec<AttackClassForTemplate>,
+    pub campaigns: Vec<CampaignForTemplate>,
+    pub countries: Vec<CountryForTemplate>,
+    pub heatmap: HeatmapForTemplate,
+    pub feed_events: Vec<FeedEventForTemplate>,
+    pub mcp_risk: McpRiskForTemplate,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AttackClassForTemplate {
+    pub name: String,
+    pub surface: String,
+    pub goal: String,
+    pub severity: String,
+    pub count: usize,
+    pub detections: usize,
+    pub unique_sources: usize,
+    pub latest_relative: String,
+    pub share_pct: usize,
+    pub css_class: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct CampaignForTemplate {
+    pub label: String,
+    pub attack_class: String,
+    pub surface: String,
+    pub goal: String,
+    pub severity: String,
+    pub count: usize,
+    pub detections: usize,
+    pub source_ip: String,
+    pub country_code: String,
+    pub user_agent: String,
+    pub sample_path: String,
+    pub first_seen_iso: String,
+    pub last_seen_iso: String,
+    pub duration: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct CountryForTemplate {
+    pub code: String,
+    pub name: String,
+    pub count: usize,
+    pub detections: usize,
+    pub unique_sources: usize,
+    pub top_class: String,
+    pub share_pct: usize,
+    pub has_position: bool,
+    pub x: i32,
+    pub y: i32,
+    pub radius: i32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HeatmapForTemplate {
+    pub detectors: Vec<String>,
+    pub rows: Vec<HeatmapRowForTemplate>,
+    pub max_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HeatmapRowForTemplate {
+    pub detector: String,
+    pub cells: Vec<HeatmapCellForTemplate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HeatmapCellForTemplate {
+    pub count: usize,
+    pub bucket: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct FeedEventForTemplate {
+    pub id: i64,
+    pub iso: String,
+    pub relative: String,
+    pub surface: String,
+    pub attack_class: String,
+    pub goal: String,
+    pub severity: String,
+    pub source_ip: String,
+    pub country_code: String,
+    pub method: String,
+    pub path: String,
+    pub user_agent: String,
+    pub detections: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct McpRiskForTemplate {
+    pub sessions: usize,
+    pub suspicious_sessions: usize,
+    pub tool_calls: usize,
+    pub tool_calls_with_detections: usize,
+    pub unknown_methods: usize,
+    pub score: usize,
+    pub label: String,
+}
+
+#[derive(Debug, Clone)]
+struct AttackClass {
+    name: &'static str,
+    surface: &'static str,
+    goal: &'static str,
+    severity: &'static str,
+}
+
+#[derive(Default)]
+struct AttackClassAgg {
+    name: String,
+    surface: String,
+    goal: String,
+    severity: String,
+    count: usize,
+    detections: usize,
+    latest_ms: i64,
+    sources: BTreeSet<String>,
+}
+
+#[derive(Default)]
+struct CampaignAgg {
+    attack_class: String,
+    surface: String,
+    goal: String,
+    severity: String,
+    count: usize,
+    detections: usize,
+    source_ip: String,
+    country_code: String,
+    user_agent: String,
+    sample_path: String,
+    first_ms: i64,
+    last_ms: i64,
+}
+
+#[derive(Default)]
+struct CountryAgg {
+    code: String,
+    count: usize,
+    detections: usize,
+    sources: BTreeSet<String>,
+    classes: HashMap<String, usize>,
+}
+
+pub(super) fn build_dashboard_analytics(rows: &[RawEventRow], now_ms: i64) -> DashboardAnalytics {
+    let rows = if rows.len() > MAX_DASHBOARD_ROWS {
+        &rows[..MAX_DASHBOARD_ROWS]
+    } else {
+        rows
+    };
+
+    let mut classes: BTreeMap<String, AttackClassAgg> = BTreeMap::new();
+    let mut campaigns: BTreeMap<String, CampaignAgg> = BTreeMap::new();
+    let mut countries: BTreeMap<String, CountryAgg> = BTreeMap::new();
+    let mut detection_count = 0usize;
+
+    for row in rows {
+        let detectors = detector_names(row);
+        detection_count += detectors.len();
+        let class = classify(row, &detectors);
+        let source_ip = source_ip(row);
+        let country = country_code(row);
+        let path = path_label(row);
+
+        let class_entry = classes
+            .entry(class.name.to_string())
+            .or_insert_with(|| AttackClassAgg {
+                name: class.name.to_string(),
+                surface: class.surface.to_string(),
+                goal: class.goal.to_string(),
+                severity: class.severity.to_string(),
+                ..Default::default()
+            });
+        class_entry.count += 1;
+        class_entry.detections += detectors.len();
+        class_entry.latest_ms = class_entry.latest_ms.max(row.timestamp_ms);
+        class_entry.sources.insert(source_ip.clone());
+
+        let campaign_key = format!(
+            "{}\0{}\0{}",
+            source_ip,
+            row.user_agent.as_deref().unwrap_or("-"),
+            class.name
+        );
+        let campaign = campaigns
+            .entry(campaign_key)
+            .or_insert_with(|| CampaignAgg {
+                attack_class: class.name.to_string(),
+                surface: class.surface.to_string(),
+                goal: class.goal.to_string(),
+                severity: class.severity.to_string(),
+                source_ip: source_ip.clone(),
+                country_code: country.clone(),
+                user_agent: row.user_agent.clone().unwrap_or_else(|| "-".into()),
+                sample_path: path.clone(),
+                first_ms: row.timestamp_ms,
+                last_ms: row.timestamp_ms,
+                ..Default::default()
+            });
+        campaign.count += 1;
+        campaign.detections += detectors.len();
+        campaign.first_ms = campaign.first_ms.min(row.timestamp_ms);
+        campaign.last_ms = campaign.last_ms.max(row.timestamp_ms);
+        if campaign.sample_path == "-" && path != "-" {
+            campaign.sample_path = path;
+        }
+
+        let country_entry = countries
+            .entry(country.clone())
+            .or_insert_with(|| CountryAgg {
+                code: country.clone(),
+                ..Default::default()
+            });
+        country_entry.count += 1;
+        country_entry.detections += detectors.len();
+        country_entry.sources.insert(source_ip);
+        *country_entry
+            .classes
+            .entry(class.name.to_string())
+            .or_insert(0) += 1;
+    }
+
+    let total_events = rows.len().max(1);
+    let mut attack_classes: Vec<_> = classes
+        .into_values()
+        .map(|a| AttackClassForTemplate {
+            css_class: slug(&a.name),
+            share_pct: percent(a.count, total_events),
+            latest_relative: relative(a.latest_ms, now_ms),
+            unique_sources: a.sources.len(),
+            name: a.name,
+            surface: a.surface,
+            goal: a.goal,
+            severity: a.severity,
+            count: a.count,
+            detections: a.detections,
+        })
+        .collect();
+    attack_classes.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| severity_rank(&b.severity).cmp(&severity_rank(&a.severity)))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    attack_classes.truncate(10);
+
+    let mut campaigns: Vec<_> = campaigns
+        .into_values()
+        .map(|c| CampaignForTemplate {
+            label: format!("{} / {}", c.source_ip, truncate(&c.attack_class, 36)),
+            attack_class: c.attack_class,
+            surface: c.surface,
+            goal: c.goal,
+            severity: c.severity,
+            count: c.count,
+            detections: c.detections,
+            source_ip: c.source_ip,
+            country_code: c.country_code,
+            user_agent: truncate(&c.user_agent, 90),
+            sample_path: truncate(&c.sample_path, 90),
+            first_seen_iso: iso(c.first_ms),
+            last_seen_iso: iso(c.last_ms),
+            duration: duration(c.last_ms.saturating_sub(c.first_ms)),
+        })
+        .collect();
+    campaigns.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| b.detections.cmp(&a.detections))
+            .then_with(|| a.source_ip.cmp(&b.source_ip))
+    });
+    campaigns.truncate(8);
+
+    let mut countries: Vec<_> = countries
+        .into_values()
+        .map(|c| {
+            let top_class = c
+                .classes
+                .iter()
+                .max_by_key(|(_, n)| **n)
+                .map(|(name, _)| name.clone())
+                .unwrap_or_else(|| "-".into());
+            let (has_position, x, y) = country_position(&c.code)
+                .map(|(x, y)| (true, x, y))
+                .unwrap_or((false, 0, 0));
+            CountryForTemplate {
+                code: c.code.clone(),
+                name: country_name(&c.code).to_string(),
+                count: c.count,
+                detections: c.detections,
+                unique_sources: c.sources.len(),
+                top_class,
+                share_pct: percent(c.count, total_events),
+                has_position,
+                x,
+                y,
+                radius: (5.0 + (c.count as f64).sqrt() * 3.0).min(22.0) as i32,
+            }
+        })
+        .collect();
+    countries.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.code.cmp(&b.code)));
+    countries.truncate(12);
+
+    DashboardAnalytics {
+        window_label: "last 24h".into(),
+        event_count: rows.len(),
+        detection_count,
+        attack_classes,
+        campaigns,
+        countries,
+        heatmap: build_heatmap(rows),
+        feed_events: rows
+            .iter()
+            .take(25)
+            .map(|row| feed_event(row, now_ms))
+            .collect(),
+        mcp_risk: build_mcp_risk(rows),
+    }
+}
+
+pub(super) fn feed_event(row: &RawEventRow, now_ms: i64) -> FeedEventForTemplate {
+    let detectors = detector_names(row);
+    let class = classify(row, &detectors);
+    FeedEventForTemplate {
+        id: row.id,
+        iso: iso(row.timestamp_ms),
+        relative: relative(row.timestamp_ms, now_ms),
+        surface: class.surface.to_string(),
+        attack_class: class.name.to_string(),
+        goal: class.goal.to_string(),
+        severity: class.severity.to_string(),
+        source_ip: source_ip(row),
+        country_code: country_code(row),
+        method: row.method.clone(),
+        path: path_label(row),
+        user_agent: truncate(row.user_agent.as_deref().unwrap_or("-"), 90),
+        detections: detectors,
+    }
+}
+
+pub(super) fn render_markdown_report(
+    analytics: &DashboardAnalytics,
+    include_operator: bool,
+) -> String {
+    let mut out = String::new();
+    out.push_str("# honeymcp attack report\n\n");
+    out.push_str(&format!(
+        "- Window: {}\n- Scope: {}\n- Events: {}\n- Detector hits: {}\n\n",
+        analytics.window_label,
+        if include_operator {
+            "external + operator"
+        } else {
+            "external only"
+        },
+        analytics.event_count,
+        analytics.detection_count
+    ));
+
+    out.push_str("## Attack classes\n\n");
+    if analytics.attack_classes.is_empty() {
+        out.push_str("No events in this window.\n\n");
+    } else {
+        out.push_str("| Class | Surface | Goal | Events | Detections | Sources |\n");
+        out.push_str("|---|---:|---|---:|---:|---:|\n");
+        for a in &analytics.attack_classes {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {} | {} |\n",
+                a.name, a.surface, a.goal, a.count, a.detections, a.unique_sources
+            ));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Campaigns\n\n");
+    if analytics.campaigns.is_empty() {
+        out.push_str("No campaign groups in this window.\n\n");
+    } else {
+        out.push_str("| Source | Country | Class | Events | Duration | Sample |\n");
+        out.push_str("|---|---:|---|---:|---:|---|\n");
+        for c in &analytics.campaigns {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {} | `{}` |\n",
+                c.source_ip, c.country_code, c.attack_class, c.count, c.duration, c.sample_path
+            ));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Source countries\n\n");
+    if analytics.countries.is_empty() {
+        out.push_str("No country signal in this window.\n\n");
+    } else {
+        out.push_str("| Country | Events | Sources | Top class |\n");
+        out.push_str("|---|---:|---:|---|\n");
+        for c in &analytics.countries {
+            out.push_str(&format!(
+                "| {} ({}) | {} | {} | {} |\n",
+                c.name, c.code, c.count, c.unique_sources, c.top_class
+            ));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## MCP risk\n\n");
+    out.push_str(&format!(
+        "- Label: {}\n- Sessions: {}\n- Suspicious sessions: {}\n- Tool calls: {}\n- Tool calls with detections: {}\n- Unknown methods: {}\n- Score: {}/100\n",
+        analytics.mcp_risk.label,
+        analytics.mcp_risk.sessions,
+        analytics.mcp_risk.suspicious_sessions,
+        analytics.mcp_risk.tool_calls,
+        analytics.mcp_risk.tool_calls_with_detections,
+        analytics.mcp_risk.unknown_methods,
+        analytics.mcp_risk.score
+    ));
+
+    out
+}
+
+pub(super) fn render_persona_sankey_svg(rows: &[RawEventRow], now_ms: i64) -> String {
+    let mut flows: HashMap<(String, String), usize> = HashMap::new();
+    for row in rows.iter().take(MAX_DASHBOARD_ROWS) {
+        let detectors = detector_names(row);
+        let class = classify(row, &detectors);
+        let persona = row
+            .persona
+            .clone()
+            .unwrap_or_else(|| "probe surface".into());
+        *flows.entry((persona, class.name.to_string())).or_insert(0) += 1;
+    }
+
+    let mut flows: Vec<_> = flows.into_iter().collect();
+    flows.sort_by(|a, b| b.1.cmp(&a.1));
+    flows.truncate(12);
+
+    let width = 860;
+    let height = 110 + (flows.len().max(1) as i32 * 34);
+    let max = flows.iter().map(|(_, n)| *n).max().unwrap_or(1);
+    let mut y = 78;
+    let mut body = String::new();
+    body.push_str(&format!(
+        r##"<text x="24" y="32" fill="#d8e3df" font-size="15" font-family="Inter, system-ui, sans-serif" font-weight="600">Persona vs observed intent</text>
+<text x="24" y="52" fill="#7e8b86" font-size="11" font-family="ui-monospace, monospace">external-only projection, {}</text>"##,
+        escape_xml(&relative(now_ms - 24 * 60 * 60 * 1000, now_ms))
+    ));
+
+    if flows.is_empty() {
+        body.push_str(
+            r##"<text x="24" y="92" fill="#7e8b86" font-size="12" font-family="ui-monospace, monospace">no flows in window</text>"##,
+        );
+    }
+
+    for ((persona, target), count) in flows {
+        let stroke = (2.0 + (count as f64 / max as f64) * 18.0) as i32;
+        let x1 = 190;
+        let x2 = 610;
+        body.push_str(&format!(
+            r##"<text x="24" y="{y}" fill="#a8e068" font-size="12" font-family="ui-monospace, monospace">{}</text>
+<path d="M {x1} {y} C 330 {}, 470 {}, {x2} {y}" fill="none" stroke="#a8e068" stroke-opacity="0.45" stroke-width="{stroke}" stroke-linecap="round"/>
+<text x="640" y="{y}" fill="#d8e3df" font-size="12" font-family="ui-monospace, monospace">{} <tspan fill="#7e8b86">({count})</tspan></text>"##,
+            escape_xml(&truncate(&persona, 22)),
+            y - 18,
+            y + 18,
+            escape_xml(&truncate(&target, 34)),
+        ));
+        y += 34;
+    }
+
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}" style="background:#0a0d0e;border-radius:4px;">
+{body}
+</svg>"##
+    )
+}
+
+fn build_heatmap(rows: &[RawEventRow]) -> HeatmapForTemplate {
+    let mut session_detectors: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut detector_freq: HashMap<String, usize> = HashMap::new();
+
+    for row in rows {
+        let detectors = detector_names(row);
+        if detectors.is_empty() {
+            continue;
+        }
+        let entry = session_detectors.entry(row.session_id.clone()).or_default();
+        for detector in detectors {
+            *detector_freq.entry(detector.clone()).or_insert(0) += 1;
+            entry.insert(detector);
+        }
+    }
+
+    let mut detectors: Vec<_> = detector_freq.into_iter().collect();
+    detectors.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let detectors: Vec<String> = detectors.into_iter().take(8).map(|(d, _)| d).collect();
+
+    let mut pair_counts: HashMap<(String, String), usize> = HashMap::new();
+    for detector_set in session_detectors.values() {
+        for a in &detectors {
+            if !detector_set.contains(a) {
+                continue;
+            }
+            for b in &detectors {
+                if detector_set.contains(b) {
+                    *pair_counts.entry((a.clone(), b.clone())).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    let max_count = pair_counts.values().copied().max().unwrap_or(0);
+    let rows = detectors
+        .iter()
+        .map(|a| {
+            let cells = detectors
+                .iter()
+                .map(|b| {
+                    let count = pair_counts
+                        .get(&(a.clone(), b.clone()))
+                        .copied()
+                        .unwrap_or(0);
+                    HeatmapCellForTemplate {
+                        count,
+                        bucket: bucket(count, max_count),
+                    }
+                })
+                .collect();
+            HeatmapRowForTemplate {
+                detector: a.clone(),
+                cells,
+            }
+        })
+        .collect();
+
+    HeatmapForTemplate {
+        detectors,
+        rows,
+        max_count,
+    }
+}
+
+fn build_mcp_risk(rows: &[RawEventRow]) -> McpRiskForTemplate {
+    #[derive(Default)]
+    struct SessionRisk {
+        tool_calls: usize,
+        detected_tool_calls: usize,
+        unknown_methods: usize,
+        detections: usize,
+    }
+
+    let mut sessions: BTreeMap<String, SessionRisk> = BTreeMap::new();
+    for row in rows.iter().filter(|r| r.method != "probe") {
+        let detectors = detector_names(row);
+        let s = sessions.entry(row.session_id.clone()).or_default();
+        s.detections += detectors.len();
+        if row.method == "tools/call" {
+            s.tool_calls += 1;
+            if !detectors.is_empty() {
+                s.detected_tool_calls += 1;
+            }
+        }
+        if row.response_summary.starts_with("method-not-found:") {
+            s.unknown_methods += 1;
+        }
+    }
+
+    let sessions_n = sessions.len();
+    let suspicious_sessions = sessions
+        .values()
+        .filter(|s| s.detected_tool_calls > 0 || s.unknown_methods > 0 || s.detections >= 2)
+        .count();
+    let tool_calls: usize = sessions.values().map(|s| s.tool_calls).sum();
+    let tool_calls_with_detections: usize = sessions.values().map(|s| s.detected_tool_calls).sum();
+    let unknown_methods: usize = sessions.values().map(|s| s.unknown_methods).sum();
+    let score = (tool_calls_with_detections * 30 + unknown_methods * 10 + suspicious_sessions * 15)
+        .min(100);
+    let label = if score >= 70 {
+        "high"
+    } else if score >= 30 {
+        "medium"
+    } else if sessions_n > 0 {
+        "low"
+    } else {
+        "quiet"
+    };
+
+    McpRiskForTemplate {
+        sessions: sessions_n,
+        suspicious_sessions,
+        tool_calls,
+        tool_calls_with_detections,
+        unknown_methods,
+        score,
+        label: label.into(),
+    }
+}
+
+fn classify(row: &RawEventRow, detectors: &[String]) -> AttackClass {
+    if row.method != "probe" {
+        return classify_mcp(row, detectors);
+    }
+
+    let haystack = probe_haystack(row);
+    if haystack.contains(".env") || haystack.contains(".git/config") {
+        AttackClass {
+            name: ".env / config exfil",
+            surface: "probe",
+            goal: "read framework, git or cloud secrets from exposed files",
+            severity: "critical",
+        }
+    } else if haystack.contains("eval-stdin.php") || haystack.contains("phpunit") {
+        AttackClass {
+            name: "PHPUnit eval-stdin RCE",
+            surface: "probe",
+            goal: "execute PHP through exposed PHPUnit test helpers",
+            severity: "critical",
+        }
+    } else if haystack.contains("phpinfo") {
+        AttackClass {
+            name: "phpinfo disclosure",
+            surface: "probe",
+            goal: "fingerprint PHP runtime, paths, env and loaded modules",
+            severity: "medium",
+        }
+    } else if haystack.contains("thinkphp")
+        || haystack.contains("invokefunction")
+        || haystack.contains("call_user_func")
+    {
+        AttackClass {
+            name: "ThinkPHP RCE probe",
+            surface: "probe",
+            goal: "reach known ThinkPHP function-invocation RCE chains",
+            severity: "critical",
+        }
+    } else if haystack.contains("/cgi-bin/") && encoded_dotdot(&haystack) {
+        AttackClass {
+            name: "CGI traversal to shell",
+            surface: "probe",
+            goal: "escape CGI path handling and execute /bin/sh",
+            severity: "critical",
+        }
+    } else if haystack.contains("auto_prepend_file")
+        || haystack.contains("allow_url_include")
+        || haystack.contains("-d+")
+    {
+        AttackClass {
+            name: "PHP-CGI argument injection",
+            surface: "probe",
+            goal: "set PHP runtime flags and include attacker-controlled code",
+            severity: "critical",
+        }
+    } else if haystack.contains("../")
+        || encoded_dotdot(&haystack)
+        || haystack.contains("/etc/passwd")
+    {
+        AttackClass {
+            name: "path traversal / LFI",
+            surface: "probe",
+            goal: "read local files outside the web root",
+            severity: "high",
+        }
+    } else if haystack.contains("_ignition") || haystack.contains("ignition") {
+        AttackClass {
+            name: "Laravel Ignition probe",
+            surface: "probe",
+            goal: "find debug endpoints linked to historical RCE chains",
+            severity: "high",
+        }
+    } else if haystack.contains("/containers/json") || haystack.contains("docker") {
+        AttackClass {
+            name: "Docker API discovery",
+            surface: "probe",
+            goal: "find an exposed Docker daemon or container inventory",
+            severity: "high",
+        }
+    } else if haystack.contains("geoserver") {
+        AttackClass {
+            name: "GeoServer exploit probe",
+            surface: "probe",
+            goal: "reach known GeoServer exploit paths",
+            severity: "high",
+        }
+    } else if haystack.contains("metadata.google.internal")
+        || haystack.contains("169.254.169.254")
+        || haystack.contains("/computeMetadata/")
+    {
+        AttackClass {
+            name: "cloud metadata probe",
+            surface: "probe",
+            goal: "reach instance metadata credentials",
+            severity: "critical",
+        }
+    } else if haystack.contains("setup.cgi") || haystack.contains("mozi") {
+        AttackClass {
+            name: "router command injection",
+            surface: "probe",
+            goal: "drop malware through embedded-device command injection",
+            severity: "critical",
+        }
+    } else if haystack.contains("/admin")
+        || haystack.contains("wp-login")
+        || haystack.contains("login")
+        || haystack.contains("boaform")
+    {
+        AttackClass {
+            name: "admin/login discovery",
+            surface: "probe",
+            goal: "discover management panels or default login surfaces",
+            severity: "low",
+        }
+    } else if detectors.iter().any(|d| d == "scanner_fingerprint") {
+        AttackClass {
+            name: "internet scanner fingerprint",
+            surface: "probe",
+            goal: "inventory service banners and reachable paths",
+            severity: "low",
+        }
+    } else {
+        AttackClass {
+            name: "generic web probe",
+            surface: "probe",
+            goal: "fingerprint unmodelled HTTP surface",
+            severity: "low",
+        }
+    }
+}
+
+fn classify_mcp(row: &RawEventRow, detectors: &[String]) -> AttackClass {
+    if detectors
+        .iter()
+        .any(|d| d == "secret_exfil_targets" || d == "ssrf_imds")
+    {
+        AttackClass {
+            name: "MCP credential/cloud exfil",
+            surface: "mcp",
+            goal: "use MCP tools to read secrets, config or cloud metadata",
+            severity: "critical",
+        }
+    } else if detectors.iter().any(|d| d == "shell_injection_patterns") {
+        AttackClass {
+            name: "MCP command injection",
+            surface: "mcp",
+            goal: "push shell metacharacters through tool arguments",
+            severity: "critical",
+        }
+    } else if detectors
+        .iter()
+        .any(|d| d == "prompt_injection_markers" || d == "unicode_anomaly")
+    {
+        AttackClass {
+            name: "MCP prompt/tool abuse",
+            surface: "mcp",
+            goal: "coerce agent instructions or hide malicious content",
+            severity: "high",
+        }
+    } else if row.method == "tools/call" {
+        AttackClass {
+            name: "MCP tool execution",
+            surface: "mcp",
+            goal: "execute a fake tool and observe returned data",
+            severity: "medium",
+        }
+    } else if row.method == "tools/list" || detectors.iter().any(|d| d == "tool_enumeration") {
+        AttackClass {
+            name: "MCP tool enumeration",
+            surface: "mcp",
+            goal: "list available tools and server capability shape",
+            severity: "low",
+        }
+    } else if row.method == "initialize" || row.method == "notifications/initialized" {
+        AttackClass {
+            name: "MCP handshake recon",
+            surface: "mcp",
+            goal: "fingerprint protocol version, persona and server info",
+            severity: "low",
+        }
+    } else if row.response_summary.starts_with("method-not-found:") {
+        AttackClass {
+            name: "MCP method fuzzing",
+            surface: "mcp",
+            goal: "probe unsupported JSON-RPC methods",
+            severity: "medium",
+        }
+    } else {
+        AttackClass {
+            name: "MCP protocol probe",
+            surface: "mcp",
+            goal: "exercise MCP transport behaviour",
+            severity: "low",
+        }
+    }
+}
+
+pub(super) fn source_ip(row: &RawEventRow) -> String {
+    if let Some(meta) = row.client_meta.as_deref() {
+        if let Ok(v) = serde_json::from_str::<Value>(meta) {
+            if let Some(cf) = v.get("cf_connecting_ip").and_then(|x| x.as_str()) {
+                if !cf.trim().is_empty() {
+                    return cf.trim().to_string();
+                }
+            }
+            if let Some(real) = v.get("x_real_ip").and_then(|x| x.as_str()) {
+                if !real.trim().is_empty() {
+                    return real.trim().to_string();
+                }
+            }
+            if let Some(xff) = v.get("x_forwarded_for").and_then(|x| x.as_str()) {
+                if let Some(first) = xff.split(',').map(str::trim).find(|s| !s.is_empty()) {
+                    return first.to_string();
+                }
+            }
+        }
+    }
+    row.remote_addr
+        .as_deref()
+        .map(strip_port)
+        .unwrap_or("-")
+        .to_string()
+}
+
+fn country_code(row: &RawEventRow) -> String {
+    if let Some(meta) = row.client_meta.as_deref() {
+        if let Ok(v) = serde_json::from_str::<Value>(meta) {
+            for key in ["cf_ipcountry", "geoip_country", "country_code", "country"] {
+                if let Some(code) = v.get(key).and_then(|x| x.as_str()) {
+                    let code = code.trim().to_ascii_uppercase();
+                    if code.len() == 2 && code != "XX" && code != "T1" {
+                        return code;
+                    }
+                }
+            }
+        }
+    }
+
+    let ip = source_ip(row);
+    match ip.parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) if is_private_or_reserved_v4(v4) => "PRIVATE".into(),
+        Ok(IpAddr::V6(v6))
+            if v6.is_loopback() || v6.is_unique_local() || v6.is_unicast_link_local() =>
+        {
+            "PRIVATE".into()
+        }
+        _ => "ZZ".into(),
+    }
+}
+
+fn detector_names(row: &RawEventRow) -> Vec<String> {
+    let Some(raw) = row.detections_json.as_deref() else {
+        return Vec::new();
+    };
+    if raw.is_empty() || raw == "null" {
+        return Vec::new();
+    }
+    let Ok(v) = serde_json::from_str::<Value>(raw) else {
+        return Vec::new();
+    };
+    v.as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|d| d.get("detector").and_then(|x| x.as_str()))
+        .map(str::to_string)
+        .collect()
+}
+
+fn path_label(row: &RawEventRow) -> String {
+    if row.method != "probe" {
+        if row.method == "tools/call" {
+            return tool_name(row).unwrap_or_else(|| "tools/call".into());
+        }
+        return row.method.clone();
+    }
+    let Some(params) = row.params.as_deref() else {
+        return "-".into();
+    };
+    let Ok(v) = serde_json::from_str::<Value>(params) else {
+        return "-".into();
+    };
+    let path = v.get("path").and_then(|x| x.as_str()).unwrap_or("-");
+    let query = v.get("query").and_then(|x| x.as_str());
+    match query {
+        Some(q) if !q.is_empty() => format!("{path}?{}", truncate(q, 60)),
+        _ => path.to_string(),
+    }
+}
+
+fn tool_name(row: &RawEventRow) -> Option<String> {
+    let params = row.params.as_deref()?;
+    let v = serde_json::from_str::<Value>(params).ok()?;
+    v.get("name").and_then(|x| x.as_str()).map(str::to_string)
+}
+
+fn probe_haystack(row: &RawEventRow) -> String {
+    let mut s = row.response_summary.to_ascii_lowercase();
+    if let Some(params) = row.params.as_deref() {
+        s.push(' ');
+        s.push_str(&params.to_ascii_lowercase());
+    }
+    s
+}
+
+fn strip_port(addr: &str) -> &str {
+    if addr.starts_with('[') {
+        return addr
+            .split_once(']')
+            .map(|(host, _)| host.trim_start_matches('['))
+            .unwrap_or(addr);
+    }
+    addr.rsplit_once(':')
+        .and_then(|(host, port)| port.parse::<u16>().ok().map(|_| host))
+        .unwrap_or(addr)
+}
+
+fn is_private_or_reserved_v4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, _] = ip.octets();
+    a == 10
+        || a == 127
+        || a == 0
+        || (a == 172 && (16..=31).contains(&b))
+        || (a == 192 && b == 168)
+        || (a == 169 && b == 254)
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113)
+}
+
+fn encoded_dotdot(s: &str) -> bool {
+    s.contains("%2e%2e") || s.contains(".%2e") || s.contains("%2e.") || s.contains("%252e")
+}
+
+fn severity_rank(severity: &str) -> usize {
+    match severity {
+        "critical" => 4,
+        "high" => 3,
+        "medium" => 2,
+        "low" => 1,
+        _ => 0,
+    }
+}
+
+fn percent(n: usize, total: usize) -> usize {
+    if total == 0 {
+        0
+    } else {
+        ((n as f64 / total as f64) * 100.0).round() as usize
+    }
+}
+
+fn bucket(count: usize, max: usize) -> usize {
+    if count == 0 || max == 0 {
+        0
+    } else {
+        ((count as f64 / max as f64) * 4.0).ceil() as usize
+    }
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(n).collect();
+        out.push_str(" ...");
+        out
+    }
+}
+
+fn slug(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn iso(ms: i64) -> String {
+    let secs = ms / 1000;
+    time::OffsetDateTime::from_unix_timestamp(secs)
+        .ok()
+        .and_then(|t| {
+            t.format(&time::format_description::well_known::Rfc3339)
+                .ok()
+        })
+        .unwrap_or_else(|| format!("@{ms}"))
+}
+
+fn relative(ts_ms: i64, now_ms: i64) -> String {
+    let dt = (now_ms - ts_ms).max(0);
+    let s = dt / 1000;
+    if s < 60 {
+        format!("{s}s ago")
+    } else if s < 3600 {
+        format!("{}m ago", s / 60)
+    } else if s < 86400 {
+        format!("{}h ago", s / 3600)
+    } else {
+        format!("{}d ago", s / 86400)
+    }
+}
+
+fn duration(ms: i64) -> String {
+    let s = ms / 1000;
+    if s < 60 {
+        format!("{s}s")
+    } else if s < 3600 {
+        format!("{}m", s / 60)
+    } else {
+        format!("{}h", s / 3600)
+    }
+}
+
+fn country_position(code: &str) -> Option<(i32, i32)> {
+    let (lat, lon): (f64, f64) = match code {
+        "US" => (39.8, -98.6),
+        "CA" => (56.1, -106.3),
+        "MX" => (23.6, -102.5),
+        "BR" => (-14.2, -51.9),
+        "AR" => (-38.4, -63.6),
+        "CL" => (-35.7, -71.5),
+        "GB" => (55.4, -3.4),
+        "IE" => (53.4, -8.2),
+        "FR" => (46.2, 2.2),
+        "DE" => (51.2, 10.4),
+        "NL" => (52.1, 5.3),
+        "BE" => (50.5, 4.5),
+        "CH" => (46.8, 8.2),
+        "AT" => (47.5, 14.6),
+        "IT" => (41.9, 12.6),
+        "ES" => (40.5, -3.7),
+        "PT" => (39.4, -8.2),
+        "PL" => (51.9, 19.1),
+        "CZ" => (49.8, 15.5),
+        "RO" => (45.9, 24.9),
+        "BG" => (42.7, 25.5),
+        "UA" => (49.0, 31.4),
+        "RU" => (61.5, 105.3),
+        "SE" => (60.1, 18.6),
+        "NO" => (60.5, 8.5),
+        "FI" => (61.9, 25.7),
+        "DK" => (56.3, 9.5),
+        "TR" => (39.0, 35.2),
+        "IL" => (31.0, 35.0),
+        "AE" => (24.0, 54.0),
+        "SA" => (24.0, 45.0),
+        "IR" => (32.4, 53.7),
+        "ZA" => (-30.6, 22.9),
+        "CN" => (35.9, 104.2),
+        "HK" => (22.3, 114.2),
+        "TW" => (23.7, 121.0),
+        "JP" => (36.2, 138.3),
+        "KR" => (36.5, 127.9),
+        "SG" => (1.35, 103.8),
+        "IN" => (20.6, 78.9),
+        "ID" => (-0.8, 113.9),
+        "TH" => (15.9, 101.0),
+        "VN" => (14.1, 108.3),
+        "AU" => (-25.3, 133.8),
+        _ => return None,
+    };
+    let x = (((lon + 180.0) / 360.0) * 640.0).round() as i32;
+    let y = (((90.0 - lat) / 180.0) * 260.0).round() as i32;
+    Some((x, y))
+}
+
+fn country_name(code: &str) -> &'static str {
+    match code {
+        "US" => "United States",
+        "CA" => "Canada",
+        "MX" => "Mexico",
+        "BR" => "Brazil",
+        "AR" => "Argentina",
+        "CL" => "Chile",
+        "GB" => "United Kingdom",
+        "IE" => "Ireland",
+        "FR" => "France",
+        "DE" => "Germany",
+        "NL" => "Netherlands",
+        "BE" => "Belgium",
+        "CH" => "Switzerland",
+        "AT" => "Austria",
+        "IT" => "Italy",
+        "ES" => "Spain",
+        "PT" => "Portugal",
+        "PL" => "Poland",
+        "CZ" => "Czechia",
+        "RO" => "Romania",
+        "BG" => "Bulgaria",
+        "UA" => "Ukraine",
+        "RU" => "Russia",
+        "SE" => "Sweden",
+        "NO" => "Norway",
+        "FI" => "Finland",
+        "DK" => "Denmark",
+        "TR" => "Turkey",
+        "IL" => "Israel",
+        "AE" => "United Arab Emirates",
+        "SA" => "Saudi Arabia",
+        "IR" => "Iran",
+        "ZA" => "South Africa",
+        "CN" => "China",
+        "HK" => "Hong Kong",
+        "TW" => "Taiwan",
+        "JP" => "Japan",
+        "KR" => "South Korea",
+        "SG" => "Singapore",
+        "IN" => "India",
+        "ID" => "Indonesia",
+        "TH" => "Thailand",
+        "VN" => "Vietnam",
+        "AU" => "Australia",
+        "PRIVATE" => "private/reserved",
+        "ZZ" => "unknown",
+        _ => "unmapped",
+    }
+}
+
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(method: &str, params: Value) -> RawEventRow {
+        RawEventRow {
+            id: 1,
+            timestamp_ms: 1_700_000_000_000,
+            session_id: "s1".into(),
+            method: method.into(),
+            params: Some(params.to_string()),
+            client_name: None,
+            client_version: None,
+            response_summary: "ok".into(),
+            transport: Some("http".into()),
+            remote_addr: Some("203.0.113.7:1234".into()),
+            user_agent: Some("scanner/1".into()),
+            client_meta: None,
+            persona: Some("aws".into()),
+            is_operator: false,
+            detections_json: Some("[]".into()),
+        }
+    }
+
+    fn probe(path: &str, query: Option<&str>) -> RawEventRow {
+        let mut r = row(
+            "probe",
+            serde_json::json!({
+                "http_method": "GET",
+                "path": path,
+                "query": query,
+            }),
+        );
+        r.response_summary = format!("probe GET {path}");
+        r.persona = None;
+        r
+    }
+
+    fn detected(mut r: RawEventRow, detector: &str, severity: &str) -> RawEventRow {
+        r.detections_json = Some(
+            serde_json::json!([{
+                "detector": detector,
+                "severity": severity,
+                "category": "recon",
+                "evidence": "test"
+            }])
+            .to_string(),
+        );
+        r
+    }
+
+    #[test]
+    fn classifies_dotenv_probe_as_secret_exfil() {
+        let r = probe("/.env", None);
+        let c = classify(&r, &[]);
+        assert_eq!(c.name, ".env / config exfil");
+        assert_eq!(c.severity, "critical");
+    }
+
+    #[test]
+    fn extracts_cf_country_and_source_ip() {
+        let mut r = row("initialize", serde_json::json!({}));
+        r.client_meta = Some(
+            serde_json::json!({
+                "cf_connecting_ip": "198.51.100.42",
+                "cf_ipcountry": "NL"
+            })
+            .to_string(),
+        );
+        assert_eq!(source_ip(&r), "198.51.100.42");
+        assert_eq!(country_code(&r), "NL");
+    }
+
+    #[test]
+    fn groups_repeated_rows_into_campaigns() {
+        let r1 = probe("/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php", None);
+        let mut r2 = r1.clone();
+        r2.id = 2;
+        r2.timestamp_ms += 1_000;
+        let a = build_dashboard_analytics(&[r1, r2], 1_700_000_010_000);
+        assert_eq!(a.campaigns[0].count, 2);
+        assert_eq!(a.attack_classes[0].name, "PHPUnit eval-stdin RCE");
+    }
+
+    #[test]
+    fn classifies_common_probe_families() {
+        let cases = [
+            (
+                probe("/test.php", Some("x=phpinfo()")),
+                "phpinfo disclosure",
+            ),
+            (
+                probe(
+                    "/index.php?s=/index/\\think\\app/invokefunction",
+                    Some("function=call_user_func"),
+                ),
+                "ThinkPHP RCE probe",
+            ),
+            (
+                probe("/cgi-bin/.%2e/.%2e/.%2e/.%2e/bin/sh", None),
+                "CGI traversal to shell",
+            ),
+            (
+                probe(
+                    "/index.php",
+                    Some("-d+allow_url_include=1&auto_prepend_file=php://input"),
+                ),
+                "PHP-CGI argument injection",
+            ),
+            (
+                probe("/../../../../etc/passwd", None),
+                "path traversal / LFI",
+            ),
+            (
+                probe("/_ignition/execute-solution", None),
+                "Laravel Ignition probe",
+            ),
+            (probe("/containers/json", None), "Docker API discovery"),
+            (probe("/geoserver/web/", None), "GeoServer exploit probe"),
+            (
+                probe(
+                    "/latest/meta-data/iam/security-credentials/",
+                    Some("u=169.254.169.254"),
+                ),
+                "cloud metadata probe",
+            ),
+            (
+                probe(
+                    "/setup.cgi",
+                    Some("next_file=netgear.cfg&todo=syscmd&cmd=wget+Mozi"),
+                ),
+                "router command injection",
+            ),
+            (probe("/wp-login.php", None), "admin/login discovery"),
+        ];
+
+        for (row, expected) in cases {
+            assert_eq!(classify(&row, &[]).name, expected);
+        }
+
+        let scanner = detected(probe("/random", None), "scanner_fingerprint", "low");
+        assert_eq!(
+            classify(&scanner, &detector_names(&scanner)).name,
+            "internet scanner fingerprint"
+        );
+        assert_eq!(
+            classify(&probe("/random", None), &[]).name,
+            "generic web probe"
+        );
+    }
+
+    #[test]
+    fn classifies_mcp_intent_families() {
+        let secret = detected(
+            row(
+                "tools/call",
+                serde_json::json!({"name":"read_file","arguments":{"path":"/.env"}}),
+            ),
+            "secret_exfil_targets",
+            "critical",
+        );
+        assert_eq!(
+            classify(&secret, &detector_names(&secret)).name,
+            "MCP credential/cloud exfil"
+        );
+
+        let shell = detected(
+            row(
+                "tools/call",
+                serde_json::json!({"name":"run","arguments":{"cmd":"id; whoami"}}),
+            ),
+            "shell_injection_patterns",
+            "critical",
+        );
+        assert_eq!(
+            classify(&shell, &detector_names(&shell)).name,
+            "MCP command injection"
+        );
+
+        let prompt = detected(
+            row(
+                "tools/call",
+                serde_json::json!({"name":"note","arguments":{"body":"ignore previous"}}),
+            ),
+            "prompt_injection_markers",
+            "high",
+        );
+        assert_eq!(
+            classify(&prompt, &detector_names(&prompt)).name,
+            "MCP prompt/tool abuse"
+        );
+
+        assert_eq!(
+            classify(
+                &row("tools/call", serde_json::json!({"name":"list_buckets"})),
+                &[]
+            )
+            .name,
+            "MCP tool execution"
+        );
+        assert_eq!(
+            classify(&row("tools/list", serde_json::json!({})), &[]).name,
+            "MCP tool enumeration"
+        );
+        assert_eq!(
+            classify(&row("initialize", serde_json::json!({})), &[]).name,
+            "MCP handshake recon"
+        );
+
+        let mut unknown = row("resources/list", serde_json::json!({}));
+        unknown.response_summary = "method-not-found:resources/list".into();
+        assert_eq!(classify(&unknown, &[]).name, "MCP method fuzzing");
+        assert_eq!(
+            classify(&row("ping", serde_json::json!({})), &[]).name,
+            "MCP protocol probe"
+        );
+    }
+
+    #[test]
+    fn builds_report_heatmap_country_and_risk_views() {
+        let mut r1 = detected(probe("/.env", None), "secret_exfil_targets", "critical");
+        r1.client_meta = Some(serde_json::json!({"cf_ipcountry": "NL"}).to_string());
+        let mut r2 = detected(
+            row("tools/call", serde_json::json!({"name":"read_secret"})),
+            "secret_exfil_targets",
+            "critical",
+        );
+        r2.id = 2;
+        r2.session_id = "mcp-risk".into();
+        r2.client_meta = Some(serde_json::json!({"geoip_country": "US"}).to_string());
+        let mut r3 = detected(
+            row("tools/call", serde_json::json!({"name":"read_secret"})),
+            "shell_injection_patterns",
+            "critical",
+        );
+        r3.id = 3;
+        r3.session_id = "mcp-risk".into();
+        r3.client_meta = Some(serde_json::json!({"geoip_country": "US"}).to_string());
+
+        let analytics = build_dashboard_analytics(&[r1, r2, r3], 1_700_000_020_000);
+        assert_eq!(analytics.event_count, 3);
+        assert!(analytics
+            .attack_classes
+            .iter()
+            .any(|a| a.name == "MCP credential/cloud exfil"));
+        assert!(analytics.countries.iter().any(|c| c.code == "US"));
+        assert!(analytics.heatmap.max_count > 0);
+        assert_eq!(analytics.mcp_risk.tool_calls, 2);
+        assert_eq!(analytics.mcp_risk.tool_calls_with_detections, 2);
+        assert!(analytics.mcp_risk.score >= 30);
+
+        let report = render_markdown_report(&analytics, false);
+        assert!(report.contains("honeymcp attack report"));
+        assert!(report.contains("MCP credential/cloud exfil"));
+
+        let svg = render_persona_sankey_svg(&[], 1_700_000_020_000);
+        assert!(svg.contains("no flows in window"));
+    }
+
+    #[test]
+    fn feed_event_summarises_source_path_and_detections() {
+        let r = detected(
+            probe("/.git/config", Some("a=b")),
+            "secret_exfil_targets",
+            "critical",
+        );
+        let ev = feed_event(&r, 1_700_000_030_000);
+        assert_eq!(ev.attack_class, ".env / config exfil");
+        assert_eq!(ev.path, "/.git/config?a=b");
+        assert_eq!(ev.detections, vec!["secret_exfil_targets"]);
+    }
+
+    #[test]
+    fn private_and_unknown_country_buckets_are_explicit() {
+        let mut private = row("initialize", serde_json::json!({}));
+        private.remote_addr = Some("10.0.0.5:1234".into());
+        assert_eq!(country_code(&private), "PRIVATE");
+
+        let mut unknown = row("initialize", serde_json::json!({}));
+        unknown.remote_addr = Some("8.8.8.8:53".into());
+        assert_eq!(country_code(&unknown), "ZZ");
+    }
+
+    #[test]
+    fn country_tables_cover_supported_codes() {
+        let codes = [
+            "US", "CA", "MX", "BR", "AR", "CL", "GB", "IE", "FR", "DE", "NL", "BE", "CH", "AT",
+            "IT", "ES", "PT", "PL", "CZ", "RO", "BG", "UA", "RU", "SE", "NO", "FI", "DK", "TR",
+            "IL", "AE", "SA", "IR", "ZA", "CN", "HK", "TW", "JP", "KR", "SG", "IN", "ID", "TH",
+            "VN", "AU",
+        ];
+
+        for code in codes {
+            assert!(country_position(code).is_some(), "{code}");
+            assert_ne!(country_name(code), "unmapped", "{code}");
+        }
+
+        assert_eq!(country_name("PRIVATE"), "private/reserved");
+        assert_eq!(country_name("ZZ"), "unknown");
+        assert_eq!(country_name("XY"), "unmapped");
+        assert!(country_position("XY").is_none());
+    }
+
+    #[test]
+    fn utility_helpers_cover_edge_buckets() {
+        assert_eq!(bucket(0, 10), 0);
+        assert_eq!(bucket(5, 10), 2);
+        assert_eq!(percent(1, 4), 25);
+        assert_eq!(percent(1, 0), 0);
+        assert_eq!(duration(5_000), "5s");
+        assert_eq!(duration(5 * 60_000), "5m");
+        assert_eq!(duration(2 * 3_600_000), "2h");
+        assert_eq!(severity_rank("critical"), 4);
+        assert_eq!(severity_rank("unknown"), 0);
+        assert_eq!(slug("MCP tool execution!"), "mcp-tool-execution");
+        assert_eq!(truncate("abc", 5), "abc");
+        assert!(truncate("abcdef", 3).ends_with("..."));
+        assert_eq!(escape_xml("<x&y>\""), "&lt;x&amp;y&gt;&quot;");
+    }
+}

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -9,15 +9,23 @@
 //! delivers components 1 (Attack Story Timeline) and 2 (MCP Sequence
 //! Diagram) plus the foundation that the other six components plug into.
 
+mod analytics;
+
 use std::collections::BTreeMap;
+use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    response::{Html, IntoResponse, Response},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        Html, IntoResponse, Response,
+    },
 };
+use futures::stream::Stream;
 use minijinja::{context, Environment};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -30,6 +38,8 @@ const HTMX_JS: &str = include_str!("static/htmx.min.js");
 const ALPINE_JS: &str = include_str!("static/alpine.min.js");
 const TPL_BASE: &str = include_str!("templates/base.html");
 const TPL_INDEX: &str = include_str!("templates/index.html");
+const ANALYTICS_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
+const ANALYTICS_LIMIT: i64 = 5_000;
 
 /// Compiled template environment. Cheap to clone — `Environment` keeps
 /// templates in an `Arc` internally — so we build it once at boot and hand
@@ -54,6 +64,8 @@ impl DashboardEnv {
             css => CSS_RAW,
             stats => &ctx.stats_for_template,
             sessions => &ctx.sessions,
+            analytics => &ctx.analytics,
+            view => &ctx.view,
         })?)
     }
 }
@@ -74,7 +86,6 @@ pub struct DashboardQuery {
     #[serde(default)]
     pub include_operator: bool,
     #[serde(default)]
-    #[allow(dead_code)] // reserved for future view= switch (timeline vs feed)
     pub view: Option<String>,
 }
 
@@ -140,6 +151,8 @@ struct DetectionForTemplate {
 struct IndexContext {
     stats_for_template: StatsForTemplate,
     sessions: Vec<SessionForTemplate>,
+    analytics: analytics::DashboardAnalytics,
+    view: String,
 }
 
 /// Top-level dashboard handler. Renders the timeline view; SSE live feed
@@ -178,6 +191,16 @@ pub async fn index_handler(
     };
 
     let sessions = group_into_sessions(raw_rows);
+    let analytics = match load_analytics(&state, q.include_operator).await {
+        Ok((_, analytics)) => analytics,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("analytics query: {e}"),
+            )
+                .into_response();
+        }
+    };
 
     let stats_for_template = StatsForTemplate {
         total_events: stats_snap.total_events,
@@ -198,6 +221,8 @@ pub async fn index_handler(
     let ctx = IndexContext {
         stats_for_template,
         sessions,
+        analytics,
+        view: q.view.unwrap_or_else(|| "timeline".into()),
     };
 
     match state.env.render_index(&ctx) {
@@ -208,6 +233,95 @@ pub async fn index_handler(
         )
             .into_response(),
     }
+}
+
+/// Server-Sent Events stream for the dashboard live feed. The stream polls the
+/// bounded SQLite projection and emits only rows with ids newer than the last
+/// event sent on this connection.
+pub async fn feed_handler(
+    Query(q): Query<DashboardQuery>,
+    State(state): State<DashboardState>,
+) -> Sse<impl Stream<Item = std::result::Result<Event, Infallible>>> {
+    let logger = state.logger.clone();
+    let include_operator = q.include_operator;
+
+    let stream = async_stream::stream! {
+        let mut last_id = 0i64;
+        loop {
+            let now = now_ms();
+            let since = now - ANALYTICS_WINDOW_MS;
+            match logger
+                .events_with_detections_since(since, 100, include_operator)
+                .await
+            {
+                Ok(rows) => {
+                    let mut rows: Vec<_> = rows
+                        .into_iter()
+                        .filter(|row| row.id > last_id)
+                        .collect();
+                    rows.sort_by_key(|row| row.id);
+                    for row in rows {
+                        last_id = last_id.max(row.id);
+                        let feed_event = analytics::feed_event(&row, now_ms());
+                        if let Ok(data) = serde_json::to_string(&feed_event) {
+                            yield Ok(Event::default()
+                                .event("event")
+                                .id(row.id.to_string())
+                                .data(data));
+                        }
+                    }
+                }
+                Err(e) => {
+                    yield Ok(Event::default()
+                        .event("error")
+                        .data(format!("feed query: {e}")));
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+/// Markdown summary used for copying a daily incident/corpus report without
+/// re-running ad hoc SQLite queries on the host.
+pub async fn report_handler(
+    Query(q): Query<DashboardQuery>,
+    State(state): State<DashboardState>,
+) -> Response {
+    let (_, analytics) = match load_analytics(&state, q.include_operator).await {
+        Ok(v) => v,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("report: {e}")).into_response();
+        }
+    };
+    (
+        StatusCode::OK,
+        [("content-type", "text/markdown; charset=utf-8")],
+        analytics::render_markdown_report(&analytics, q.include_operator),
+    )
+        .into_response()
+}
+
+/// Persona-vs-observed-intent Sankey-style SVG. Kept dependency-free and
+/// server-rendered like the sequence diagram.
+pub async fn sankey_handler(
+    Query(q): Query<DashboardQuery>,
+    State(state): State<DashboardState>,
+) -> Response {
+    let (rows, _) = match load_analytics(&state, q.include_operator).await {
+        Ok(v) => v,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("sankey: {e}")).into_response();
+        }
+    };
+    (
+        StatusCode::OK,
+        [("content-type", "image/svg+xml; charset=utf-8")],
+        analytics::render_persona_sankey_svg(&rows, now_ms()),
+    )
+        .into_response()
 }
 
 /// Per-session SVG sequence diagram. Rendered server-side as raw SVG so
@@ -316,7 +430,7 @@ fn build_session_for_template(session_id: String, events: Vec<RawEventRow>) -> S
     let is_operator = events.iter().any(|e| e.is_operator);
     let user_agent = last.user_agent.clone().unwrap_or_else(|| "-".to_string());
 
-    let client_ip = resolve_client_ip(last);
+    let client_ip = analytics::source_ip(last);
 
     let last_seen_iso = format_iso(last_ts);
     let last_seen_human = format_relative(last_ts, now_ms());
@@ -434,31 +548,21 @@ fn truncate(s: &str, n: usize) -> String {
     }
 }
 
-fn resolve_client_ip(e: &RawEventRow) -> String {
-    // Prefer the XFF leftmost entry from client_meta (set by the http
-    // transport when behind a reverse proxy); fall back to remote_addr
-    // stripped of port.
-    if let Some(meta) = e.client_meta.as_deref() {
-        if let Ok(v) = serde_json::from_str::<Value>(meta) {
-            if let Some(xff) = v.get("x_forwarded_for").and_then(|x| x.as_str()) {
-                if let Some(first) = xff.split(',').map(str::trim).find(|s| !s.is_empty()) {
-                    return first.to_string();
-                }
-            }
-        }
-    }
-    match e.remote_addr.as_deref() {
-        Some(a) => a
-            .rsplit_once(':')
-            .map(|(host, _)| host.trim_start_matches('[').trim_end_matches(']'))
-            .unwrap_or(a)
-            .to_string(),
-        None => "-".into(),
-    }
-}
-
 fn now_ms() -> i64 {
     crate::logger::now_ms()
+}
+
+async fn load_analytics(
+    state: &DashboardState,
+    include_operator: bool,
+) -> Result<(Vec<RawEventRow>, analytics::DashboardAnalytics)> {
+    let now = now_ms();
+    let rows = state
+        .logger
+        .events_with_detections_since(now - ANALYTICS_WINDOW_MS, ANALYTICS_LIMIT, include_operator)
+        .await?;
+    let analytics = analytics::build_dashboard_analytics(&rows, now);
+    Ok((rows, analytics))
 }
 
 fn format_iso(ms: i64) -> String {
@@ -736,6 +840,46 @@ mod tests {
     }
 
     #[test]
+    fn render_index_template_includes_intel_sections() {
+        let stats = StatsForTemplate {
+            total_events: 0,
+            total_detections: 0,
+            mcp_events: 0,
+            probe_events: 0,
+            mcp_detections: 0,
+            probe_detections: 0,
+            unique_remote_addrs_24h: 0,
+            operator_traffic_included: false,
+            server: ServerForTemplate {
+                name: "test".into(),
+                version: "1".into(),
+                protocol_version: "2025-06-18".into(),
+            },
+        };
+        let mut row = raw(
+            1,
+            now_ms(),
+            "s",
+            "probe",
+            Some(r#"{"http_method":"GET","path":"/.env","query":null}"#),
+        );
+        row.detections_json = Some(
+            r#"[{"detector":"secret_exfil_targets","severity":"critical","category":"secret_exfil","evidence":".env"}]"#
+                .into(),
+        );
+        let ctx = IndexContext {
+            stats_for_template: stats,
+            sessions: Vec::new(),
+            analytics: analytics::build_dashboard_analytics(&[row], now_ms()),
+            view: "timeline".into(),
+        };
+        let html = DashboardEnv::new().unwrap().render_index(&ctx).unwrap();
+        assert!(html.contains("attack intelligence"));
+        assert!(html.contains("source countries"));
+        assert!(html.contains("live feed"));
+    }
+
+    #[test]
     fn group_into_sessions_orders_by_first_appearance() {
         let rows = vec![
             raw(1, 1_000, "sess-a", "initialize", None),
@@ -799,7 +943,7 @@ mod tests {
         let mut row = raw(1, 0, "s", "initialize", None);
         row.client_meta = Some(r#"{"x_forwarded_for":"203.0.113.7, 10.0.0.1"}"#.into());
         row.remote_addr = Some("127.0.0.1:1234".into());
-        assert_eq!(resolve_client_ip(&row), "203.0.113.7");
+        assert_eq!(analytics::source_ip(&row), "203.0.113.7");
     }
 
     #[test]
@@ -807,7 +951,7 @@ mod tests {
         let mut row = raw(1, 0, "s", "initialize", None);
         row.client_meta = None;
         row.remote_addr = Some("198.51.100.42:51000".into());
-        assert_eq!(resolve_client_ip(&row), "198.51.100.42");
+        assert_eq!(analytics::source_ip(&row), "198.51.100.42");
     }
 
     #[test]
@@ -815,6 +959,6 @@ mod tests {
         let mut row = raw(1, 0, "s", "initialize", None);
         row.client_meta = None;
         row.remote_addr = Some("[2001:db8::1]:443".into());
-        assert_eq!(resolve_client_ip(&row), "2001:db8::1");
+        assert_eq!(analytics::source_ip(&row), "2001:db8::1");
     }
 }

--- a/src/dashboard/static/dashboard.css
+++ b/src/dashboard/static/dashboard.css
@@ -27,6 +27,7 @@
 }
 
 * { box-sizing: border-box; }
+[x-cloak] { display: none !important; }
 html, body { margin: 0; padding: 0; background: var(--hm-bg); color: var(--hm-fg); }
 body {
   font-family: var(--hm-mono);
@@ -136,12 +137,305 @@ body {
 .hm-h2 {
   font-family: var(--hm-sans);
   font-size: 22px;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   font-weight: 600;
   color: var(--hm-fg);
   margin: 0 0 6px;
 }
 .hm-h2-sub { color: var(--hm-fg-dim); font-size: 12px; margin: 0 0 16px; }
+
+/* Intelligence panels */
+.hm-intel-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(300px, 0.9fr);
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.hm-panel {
+  background: var(--hm-bg-elev);
+  border: 1px solid var(--hm-rule);
+  border-radius: var(--hm-radius);
+  padding: 16px 18px;
+  min-width: 0;
+}
+.hm-panel--wide { min-width: 0; }
+.hm-panel--embed { overflow: hidden; }
+.hm-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.hm-panel-head .hm-h2-sub { margin-bottom: 0; }
+.hm-panel-link {
+  color: var(--hm-accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--hm-accent-dim);
+  font-size: 11px;
+  white-space: nowrap;
+}
+.hm-panel-link:hover { border-bottom-color: var(--hm-accent); }
+.hm-empty { color: var(--hm-fg-dim); margin: 0; font-size: 12px; }
+
+.hm-attack-classes,
+.hm-campaigns {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.hm-attack-class,
+.hm-campaign {
+  background: var(--hm-bg);
+  border: 1px solid var(--hm-rule);
+  border-radius: var(--hm-radius);
+  padding: 10px 12px;
+  min-width: 0;
+}
+.hm-severity-left--critical { border-left: 3px solid var(--hm-crit); }
+.hm-severity-left--high { border-left: 3px solid var(--hm-warn); }
+.hm-severity-left--medium { border-left: 3px solid #d8c46a; }
+.hm-severity-left--low { border-left: 3px solid var(--hm-fg-muted); }
+.hm-attack-main,
+.hm-campaign-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.hm-attack-name,
+.hm-campaign-label {
+  color: var(--hm-fg);
+  font-weight: 600;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.hm-attack-goal,
+.hm-campaign-goal {
+  color: var(--hm-fg-dim);
+  font-size: 12px;
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+}
+.hm-attack-meta,
+.hm-campaign-meta {
+  color: var(--hm-fg-muted);
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  margin-top: 7px;
+}
+.hm-campaign-meta code {
+  color: var(--hm-accent);
+  background: var(--hm-bg-elev-2);
+  border: 1px solid var(--hm-rule);
+  border-radius: 2px;
+  padding: 1px 5px;
+  overflow-wrap: anywhere;
+}
+.hm-bar,
+.hm-risk-meter {
+  height: 4px;
+  background: var(--hm-rule);
+  border-radius: 99px;
+  overflow: hidden;
+  margin-top: 9px;
+}
+.hm-bar span,
+.hm-risk-meter span {
+  display: block;
+  height: 100%;
+  background: var(--hm-accent);
+}
+.hm-risk-meter { height: 7px; margin-bottom: 12px; }
+.hm-risk-meter span { background: linear-gradient(90deg, var(--hm-accent), var(--hm-warn), var(--hm-crit)); }
+
+.hm-kv {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin: 0;
+}
+.hm-kv div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  border-bottom: 1px solid var(--hm-rule);
+  padding-bottom: 6px;
+}
+.hm-kv dt {
+  color: var(--hm-fg-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.hm-kv dd {
+  margin: 0;
+  color: var(--hm-fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.hm-geo-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(230px, 0.7fr);
+  gap: 14px;
+  align-items: stretch;
+}
+.hm-geo-map {
+  width: 100%;
+  height: auto;
+  min-height: 230px;
+  border: 1px solid var(--hm-rule);
+  border-radius: var(--hm-radius);
+  background: var(--hm-bg);
+}
+.hm-geo-map rect { fill: var(--hm-bg); }
+.hm-geo-map path {
+  fill: none;
+  stroke: var(--hm-rule-strong);
+  stroke-width: 1;
+  stroke-dasharray: 3 5;
+}
+.hm-country-pulse circle {
+  fill: rgba(168, 224, 104, 0.22);
+  stroke: var(--hm-accent);
+  stroke-width: 1.5;
+}
+.hm-country-pulse text {
+  fill: var(--hm-fg);
+  font-family: var(--hm-mono);
+  font-size: 10px;
+  text-anchor: middle;
+}
+.hm-country-table {
+  border: 1px solid var(--hm-rule);
+  border-radius: var(--hm-radius);
+  overflow: hidden;
+  align-self: stretch;
+}
+.hm-country-row {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  gap: 8px;
+  align-items: baseline;
+  padding: 7px 9px;
+  border-bottom: 1px solid var(--hm-rule);
+  font-size: 11px;
+}
+.hm-country-row:last-child { border-bottom: 0; }
+.hm-country-code { color: var(--hm-accent); font-weight: 600; }
+.hm-country-name,
+.hm-country-class {
+  color: var(--hm-fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-country-count {
+  color: var(--hm-fg);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.hm-country-class {
+  grid-column: 2 / -1;
+  font-size: 10px;
+}
+
+.hm-heatmap-wrap { display: grid; gap: 10px; }
+.hm-heatmap {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 11px;
+}
+.hm-heatmap th,
+.hm-heatmap td {
+  border: 1px solid var(--hm-rule);
+  text-align: center;
+  height: 28px;
+  color: var(--hm-fg-dim);
+}
+.hm-heatmap th { color: var(--hm-fg-muted); font-weight: 500; }
+.hm-heat { background: var(--hm-bg); font-variant-numeric: tabular-nums; }
+.hm-heat--1 { background: rgba(168, 224, 104, 0.14); color: var(--hm-fg); }
+.hm-heat--2 { background: rgba(168, 224, 104, 0.24); color: var(--hm-fg); }
+.hm-heat--3 { background: rgba(245, 162, 93, 0.32); color: var(--hm-fg); }
+.hm-heat--4 { background: rgba(239, 84, 84, 0.42); color: var(--hm-fg); }
+.hm-heatmap-legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--hm-fg-dim);
+}
+.hm-heatmap-legend li {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 6px;
+  min-width: 0;
+}
+.hm-heatmap-legend span {
+  color: var(--hm-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.hm-sankey-preview {
+  display: block;
+  width: 100%;
+  max-height: 260px;
+  object-fit: contain;
+  border: 1px solid var(--hm-rule);
+  border-radius: var(--hm-radius);
+  background: var(--hm-bg);
+}
+
+.hm-live { margin-bottom: 24px; }
+.hm-feed-state {
+  color: var(--hm-fg-muted);
+  border: 1px solid var(--hm-rule-strong);
+  border-radius: 2px;
+  padding: 2px 7px;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.hm-feed-state--live { color: var(--hm-accent); border-color: var(--hm-accent-dim); }
+.hm-feed-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.hm-feed-row {
+  display: grid;
+  grid-template-columns: 72px 54px minmax(140px, 1fr) minmax(130px, 0.9fr) minmax(140px, 1fr) minmax(100px, 0.7fr);
+  gap: 9px;
+  align-items: baseline;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--hm-rule);
+  font-size: 11px;
+}
+.hm-feed-row time,
+.hm-feed-surface,
+.hm-feed-source,
+.hm-feed-detections {
+  color: var(--hm-fg-muted);
+}
+.hm-feed-class,
+.hm-feed-path {
+  color: var(--hm-fg);
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+.hm-feed-surface {
+  text-transform: uppercase;
+  color: var(--hm-accent);
+}
+.hm-feed-row--empty { color: var(--hm-fg-dim); display: block; }
 
 /* Session card. Backed by a native <details>/<summary> so expand/collapse
  * works without any JS at all — Alpine handles the operator toggle and the
@@ -325,5 +619,14 @@ body {
   .hm-event-detections,
   .hm-event-params { grid-column: 1; }
   .hm-overview { grid-template-columns: 1fr 1fr; }
+  .hm-intel-grid,
+  .hm-geo-layout { grid-template-columns: 1fr; }
+  .hm-panel-head { flex-direction: column; align-items: flex-start; }
+  .hm-feed-row {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+  .hm-country-row { grid-template-columns: 42px 1fr 42px; }
+  .hm-geo-map { min-height: 180px; }
   .hm-nav a:nth-child(n+3) { display: none; }
 }

--- a/src/dashboard/templates/base.html
+++ b/src/dashboard/templates/base.html
@@ -20,7 +20,9 @@
   </div>
   <nav class="hm-nav">
     <a href="/dashboard">timeline</a>
-    <a href="/dashboard?view=feed">live feed</a>
+    <a href="/dashboard?view=feed#live-feed">live feed</a>
+    <a href="/dashboard/report.md" target="_blank">report</a>
+    <a href="/dashboard/sankey.svg" target="_blank">sankey</a>
     <a href="/version" target="_blank">version</a>
     <a href="https://github.com/kosiorkosa47/honeymcp" target="_blank">repo</a>
   </nav>
@@ -46,6 +48,8 @@ function dashboardState() {
     ws_connected: false,
     include_operator: new URLSearchParams(location.search).get('include_operator') === 'true',
     provenance: { version: '...', git_sha: '...', build_time_utc: null },
+    feed_source: null,
+    live_events: [],
     async loadProvenance() {
       try {
         const r = await fetch('/version');
@@ -58,6 +62,19 @@ function dashboardState() {
       if (!t) return '?';
       try { return new Date(t).toISOString().replace('T', ' ').replace(/:\d\d\.\d+Z$/, 'Z'); }
       catch (_) { return t; }
+    },
+    connectFeed() {
+      if (this.feed_source) return;
+      const qs = this.include_operator ? '?include_operator=true' : '';
+      this.feed_source = new EventSource(`/dashboard/feed${qs}`);
+      this.feed_source.onopen = () => { this.ws_connected = true; };
+      this.feed_source.onerror = () => { this.ws_connected = false; };
+      this.feed_source.addEventListener('event', (ev) => {
+        try {
+          const item = JSON.parse(ev.data);
+          this.live_events = [item, ...this.live_events.filter((e) => e.id !== item.id)].slice(0, 25);
+        } catch (_) {}
+      });
     },
   };
 }

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -44,6 +44,215 @@
   </span>
 </section>
 
+<section class="hm-intel-grid">
+  <div class="hm-panel hm-panel--wide">
+    <div class="hm-panel-head">
+      <div>
+        <h2 class="hm-h2">attack intelligence</h2>
+        <p class="hm-h2-sub">{{ analytics.window_label }} · {{ analytics.event_count }} events · {{ analytics.detection_count }} detector hits</p>
+      </div>
+      <a class="hm-panel-link" href="/dashboard/report.md{{ '?include_operator=true' if stats.operator_traffic_included else '' }}" target="_blank">markdown report</a>
+    </div>
+    {% if analytics.attack_classes %}
+    <div class="hm-attack-classes">
+      {% for a in analytics.attack_classes %}
+      <div class="hm-attack-class hm-severity-left--{{ a.severity }}">
+        <div class="hm-attack-main">
+          <span class="hm-attack-name">{{ a.name }}</span>
+          <span class="hm-badge hm-badge--{{ 'operator' if a.surface == 'mcp' else 'external' }}">{{ a.surface }}</span>
+        </div>
+        <div class="hm-attack-goal">{{ a.goal }}</div>
+        <div class="hm-attack-meta">
+          <span>{{ a.count }} event{{ "s" if a.count != 1 else "" }}</span>
+          <span>{{ a.detections }} hit{{ "s" if a.detections != 1 else "" }}</span>
+          <span>{{ a.unique_sources }} source{{ "s" if a.unique_sources != 1 else "" }}</span>
+          <span>{{ a.latest_relative }}</span>
+        </div>
+        <div class="hm-bar"><span style="width: {{ a.share_pct }}%"></span></div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="hm-empty">no attack classes in this window.</p>
+    {% endif %}
+  </div>
+
+  <div class="hm-panel">
+    <div class="hm-panel-head">
+      <div>
+        <h2 class="hm-h2">mcp risk</h2>
+        <p class="hm-h2-sub">{{ analytics.mcp_risk.label }} · score {{ analytics.mcp_risk.score }}/100</p>
+      </div>
+    </div>
+    <div class="hm-risk-meter"><span style="width: {{ analytics.mcp_risk.score }}%"></span></div>
+    <dl class="hm-kv">
+      <div><dt>sessions</dt><dd>{{ analytics.mcp_risk.sessions }}</dd></div>
+      <div><dt>suspicious</dt><dd>{{ analytics.mcp_risk.suspicious_sessions }}</dd></div>
+      <div><dt>tool calls</dt><dd>{{ analytics.mcp_risk.tool_calls }}</dd></div>
+      <div><dt>detected calls</dt><dd>{{ analytics.mcp_risk.tool_calls_with_detections }}</dd></div>
+      <div><dt>unknown methods</dt><dd>{{ analytics.mcp_risk.unknown_methods }}</dd></div>
+    </dl>
+  </div>
+</section>
+
+<section class="hm-intel-grid">
+  <div class="hm-panel hm-panel--wide">
+    <div class="hm-panel-head">
+      <div>
+        <h2 class="hm-h2">source countries</h2>
+        <p class="hm-h2-sub">from `cf-ipcountry` or local enrichment when present; unknown stays unknown.</p>
+      </div>
+    </div>
+    <div class="hm-geo-layout">
+      <svg class="hm-geo-map" viewBox="0 0 640 260" role="img" aria-label="source country pulse map">
+        <rect x="0" y="0" width="640" height="260" rx="4"></rect>
+        <path d="M20 70 C90 35 155 45 230 72 S360 92 430 58 S545 50 620 82" />
+        <path d="M34 150 C120 120 210 138 285 165 S445 196 608 152" />
+        <path d="M98 215 C180 190 285 203 365 218 S500 242 594 208" />
+        {% for c in analytics.countries %}
+          {% if c.has_position %}
+          <g class="hm-country-pulse">
+            <circle cx="{{ c.x }}" cy="{{ c.y }}" r="{{ c.radius }}"></circle>
+            <text x="{{ c.x }}" y="{{ c.y - c.radius - 4 }}">{{ c.code }}</text>
+          </g>
+          {% endif %}
+        {% endfor %}
+      </svg>
+      <div class="hm-country-table">
+        {% for c in analytics.countries %}
+        <div class="hm-country-row">
+          <span class="hm-country-code">{{ c.code }}</span>
+          <span class="hm-country-name">{{ c.name }}</span>
+          <span class="hm-country-count">{{ c.count }}</span>
+          <span class="hm-country-class">{{ c.top_class }}</span>
+        </div>
+        {% else %}
+        <p class="hm-empty">no country signal in this window.</p>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <div class="hm-panel">
+    <div class="hm-panel-head">
+      <div>
+        <h2 class="hm-h2">detector co-occurrence</h2>
+        <p class="hm-h2-sub">same-session detector pairs</p>
+      </div>
+    </div>
+    {% if analytics.heatmap.rows %}
+    <div class="hm-heatmap-wrap">
+      <table class="hm-heatmap">
+        <thead>
+          <tr>
+            <th></th>
+            {% for d in analytics.heatmap.detectors %}
+            <th title="{{ d }}">{{ loop.index }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in analytics.heatmap.rows %}
+          <tr>
+            <th title="{{ row.detector }}">{{ loop.index }}</th>
+            {% for cell in row.cells %}
+            <td class="hm-heat hm-heat--{{ cell.bucket }}" title="{{ cell.count }}">{{ cell.count }}</td>
+            {% endfor %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <ol class="hm-heatmap-legend">
+        {% for d in analytics.heatmap.detectors %}
+        <li><span>{{ loop.index }}</span>{{ d }}</li>
+        {% endfor %}
+      </ol>
+    </div>
+    {% else %}
+    <p class="hm-empty">no detector pairs in this window.</p>
+    {% endif %}
+  </div>
+</section>
+
+<section class="hm-intel-grid">
+  <div class="hm-panel hm-panel--wide">
+    <div class="hm-panel-head">
+      <div>
+        <h2 class="hm-h2">campaigns</h2>
+        <p class="hm-h2-sub">grouped by source, user-agent and attack class</p>
+      </div>
+    </div>
+    {% if analytics.campaigns %}
+    <div class="hm-campaigns">
+      {% for c in analytics.campaigns %}
+      <div class="hm-campaign hm-severity-left--{{ c.severity }}">
+        <div class="hm-campaign-top">
+          <span class="hm-campaign-label">{{ c.label }}</span>
+          <span>{{ c.count }} event{{ "s" if c.count != 1 else "" }}</span>
+          <span>{{ c.duration }}</span>
+        </div>
+        <div class="hm-campaign-goal">{{ c.goal }}</div>
+        <div class="hm-campaign-meta">
+          <code>{{ c.country_code }}</code>
+          <code>{{ c.sample_path }}</code>
+          <span>{{ c.user_agent }}</span>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="hm-empty">no campaign groups in this window.</p>
+    {% endif %}
+  </div>
+
+  <div class="hm-panel hm-panel--embed">
+    <div class="hm-panel-head">
+      <div>
+        <h2 class="hm-h2">persona flow</h2>
+        <p class="hm-h2-sub">persona to observed intent</p>
+      </div>
+      <a class="hm-panel-link" href="/dashboard/sankey.svg{{ '?include_operator=true' if stats.operator_traffic_included else '' }}" target="_blank">open svg</a>
+    </div>
+    <img class="hm-sankey-preview" src="/dashboard/sankey.svg{{ '?include_operator=true' if stats.operator_traffic_included else '' }}" alt="Persona to observed intent flow">
+  </div>
+</section>
+
+<section id="live-feed" class="hm-panel hm-live" x-init="connectFeed()">
+  <div class="hm-panel-head">
+    <div>
+      <h2 class="hm-h2">live feed</h2>
+      <p class="hm-h2-sub">{{ analytics.window_label }} snapshot; new rows stream over SSE.</p>
+    </div>
+    <span class="hm-feed-state" :class="ws_connected ? 'hm-feed-state--live' : 'hm-feed-state--idle'" x-text="ws_connected ? 'connected' : 'connecting'"></span>
+  </div>
+  <ol class="hm-feed-list" x-show="live_events.length > 0" x-cloak>
+    <template x-for="ev in live_events" :key="ev.id">
+      <li class="hm-feed-row">
+        <time :datetime="ev.iso" x-text="ev.relative"></time>
+        <span class="hm-feed-surface" x-text="ev.surface"></span>
+        <span class="hm-feed-class" x-text="ev.attack_class"></span>
+        <span class="hm-feed-source"><span x-text="ev.country_code"></span> · <span x-text="ev.source_ip"></span></span>
+        <span class="hm-feed-path" x-text="ev.path"></span>
+        <span class="hm-feed-detections" x-text="ev.detections.join(', ')"></span>
+      </li>
+    </template>
+  </ol>
+  <ol class="hm-feed-list" x-show="live_events.length === 0">
+    {% for ev in analytics.feed_events %}
+    <li class="hm-feed-row">
+      <time datetime="{{ ev.iso }}">{{ ev.relative }}</time>
+      <span class="hm-feed-surface">{{ ev.surface }}</span>
+      <span class="hm-feed-class">{{ ev.attack_class }}</span>
+      <span class="hm-feed-source">{{ ev.country_code }} · {{ ev.source_ip }}</span>
+      <span class="hm-feed-path">{{ ev.path }}</span>
+      <span class="hm-feed-detections">{{ ev.detections | join(", ") }}</span>
+    </li>
+    {% else %}
+    <li class="hm-feed-row hm-feed-row--empty">no events in this window.</li>
+    {% endfor %}
+  </ol>
+</section>
+
 <section class="hm-timeline">
   <h2 class="hm-h2">attack story timeline</h2>
   <p class="hm-h2-sub">

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -538,6 +538,67 @@ impl Logger {
             .collect();
         Ok(rows)
     }
+
+    /// Bounded event window with detections inlined. This is the analytics
+    /// feed for dashboard panels that need "last 24h" style views rather than
+    /// the session-card window used by [`Logger::recent_events_with_detections`].
+    pub async fn events_with_detections_since(
+        &self,
+        since_ms: i64,
+        limit: i64,
+        include_operator: bool,
+    ) -> Result<Vec<RawEventRow>> {
+        let db = self.inner.db.lock().await;
+        let op_filter = if include_operator {
+            ""
+        } else {
+            "AND e.is_operator = 0"
+        };
+        let sql = format!(
+            "SELECT
+               e.id, e.timestamp_ms, e.session_id, e.method, e.params,
+               e.client_name, e.client_version, e.response_summary,
+               e.transport, e.remote_addr, e.user_agent, e.client_meta,
+               e.persona, e.is_operator,
+               (SELECT json_group_array(json_object(
+                  'detector', d.detector,
+                  'severity', d.severity,
+                  'category', d.category,
+                  'evidence', d.evidence,
+                  'mitre_techniques', d.mitre_techniques
+               ))
+                FROM detections d WHERE d.event_id = e.id) AS detections_json
+             FROM events e
+             WHERE e.timestamp_ms >= ?1 {op_filter}
+             ORDER BY e.timestamp_ms DESC
+             LIMIT ?2"
+        );
+
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params![since_ms, limit], |r| {
+                Ok(RawEventRow {
+                    id: r.get(0)?,
+                    timestamp_ms: r.get(1)?,
+                    session_id: r.get(2)?,
+                    method: r.get(3)?,
+                    params: r.get(4)?,
+                    client_name: r.get(5)?,
+                    client_version: r.get(6)?,
+                    response_summary: r.get(7)?,
+                    transport: r.get(8)?,
+                    remote_addr: r.get(9)?,
+                    user_agent: r.get(10)?,
+                    client_meta: r.get(11)?,
+                    persona: r.get(12)?,
+                    is_operator: r.get::<_, i64>(13)? != 0,
+                    detections_json: r.get(14)?,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
 }
 
 /// Wide row returned by [`Logger::recent_events_with_detections`]. Stays

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -138,6 +138,7 @@ const CAPTURED_HEADERS: &[&str] = &[
     "cf-connecting-ip",
     "cf-ipcountry",
     "cf-ray",
+    "geoip-country",
     "true-client-ip",
     "x-client-ip",
     "via",
@@ -315,6 +316,15 @@ impl Transport for HttpTransport {
                 };
                 Router::new()
                     .route("/dashboard", get(crate::dashboard::index_handler))
+                    .route("/dashboard/feed", get(crate::dashboard::feed_handler))
+                    .route(
+                        "/dashboard/report.md",
+                        get(crate::dashboard::report_handler),
+                    )
+                    .route(
+                        "/dashboard/sankey.svg",
+                        get(crate::dashboard::sankey_handler),
+                    )
                     .route(
                         "/dashboard/sequence/:session_id_svg",
                         get(crate::dashboard::sequence_handler),
@@ -864,6 +874,7 @@ mod tests {
         h.insert("accept", "application/json".parse().unwrap());
         h.insert("authorization", "Bearer attacker-token".parse().unwrap());
         h.insert("cf-ipcountry", "CN".parse().unwrap());
+        h.insert("geoip-country", "NL".parse().unwrap());
         h.insert("origin", "https://evil.test".parse().unwrap());
         h.insert("x-forwarded-for", "203.0.113.7, 10.0.0.1".parse().unwrap());
 
@@ -876,6 +887,7 @@ mod tests {
         // Curated headers captured, hyphens normalised to underscores.
         assert_eq!(m["authorization"], "Bearer attacker-token");
         assert_eq!(m["cf_ipcountry"], "CN");
+        assert_eq!(m["geoip_country"], "NL");
         assert_eq!(m["origin"], "https://evil.test");
     }
 


### PR DESCRIPTION
## What changed

- Add a versioned Caddyfile that keeps the honeypot surface public while protecting operator endpoints (`/dashboard`, `/dashboard/*`, `/stats`, `/healthz`, `/version`) behind Basic Auth.
- Keep the Basic Auth hash out of git via `/etc/honeymcp/dashboard-basic-auth`.
- Add an idempotent host-hardening script that installs the Caddyfile, enables the Docker IMDS block, and removes any accidental UFW allow rule for `8080/tcp`.
- Update auto-deploy so host hardening is applied from the checked-out repo and stamped per deployed commit.
- Add the dashboard attack-intelligence overview: attack classes, attacker-goal summaries, campaign grouping, MCP risk score, source-country pulse map, detector co-occurrence heatmap, live SSE feed, persona flow SVG, and markdown report.
- Capture `GeoIP-Country` alongside `CF-IPCountry` so reverse-proxy/local enrichment can power the country view without schema changes.
- Pass the deployed git SHA into Docker builds so `/version` remains traceable even when `.git` is absent from the build context.
- Update README, CHANGELOG, RUNBOOK, threat model, deployment/dashboard docs for the new operator surface and hardening model.

## Why

The live box was hardened manually during incident triage. That fixed the immediate exposure, but left drift between GitHub and production. This PR makes the host-side security posture reproducible from the repository while keeping dashboard credential material outside git.

The dashboard work turns raw events into the operator view needed during triage: what was attacked, what the request was trying to do, whether it touched MCP or generic web probe surface, which source/country it came from when enrichment is available, and which campaigns are repeating.

## Validation

- `sh -n deploy/apply-host-hardening.sh`
- `sh -n deploy/honeymcp-imds-block.sh`
- `bash -n deploy/auto-deploy.sh`
- `git diff --check`
- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --tests`
- `cargo clippy --all-targets --all-features -- -D warnings`
- local HTTP smoke: `/dashboard`, `/dashboard/report.md`, `/dashboard/sankey.svg`, `/dashboard/feed`
- `caddy validate --adapter caddyfile --config /tmp/honeymcp-Caddyfile` on the box using the imported hash file

## Operational note

The box has been bootstrapped with a stable `/home/ubuntu/honeymcp-autodeploy.sh` wrapper that executes `./deploy/auto-deploy.sh` from the checked-out repo. After this PR lands, future deploy behavior is controlled by GitHub. The Basic Auth plaintext password is not stored on the box.